### PR TITLE
fix pulse_pos and dist_waist implementation

### DIFF
--- a/rslaser/pulse/pulse.py
+++ b/rslaser/pulse/pulse.py
@@ -216,7 +216,7 @@ class LaserPulseSlice(ValidatorBase):
         self.num_sig_long = params.num_sig_long
         constConvRad = 1.23984186e-06/(4*3.1415926536)  ##conversion from energy to 1/wavelength
         # rmsAngDiv = constConvRad/(self.phE*params.slice_params.sigrW)             ##RMS angular divergence [rad]
-        rmsAngDiv_x = constConvRad/(self.phE * self.sigx_waist)             ##RMS angular divergence [rad]
+        rmsAngDiv_x = constConvRad/(self.phE * self.sigx_waist)                     ##RMS angular divergence [rad]
         rmsAngDiv_y = constConvRad/(self.phE * self.sigy_waist)
         sigrL_x = math.sqrt(self.sigx_waist**2 + (self.dist_waist * rmsAngDiv_x)**2)
         sigrL_y = math.sqrt(self.sigy_waist**2 + (self.dist_waist * rmsAngDiv_y)**2)
@@ -233,7 +233,8 @@ class LaserPulseSlice(ValidatorBase):
 
         # sig_s = params.tau_fwhm * const.c / 2.355
         ds = 2 * params.num_sig_long * self.sig_s / params.nslice    # longitudinal spacing between slices
-        self._pulse_pos = self.dist_waist - params.num_sig_long * self.sig_s + (slice_index + 0.5) * ds
+        # self._pulse_pos = self.dist_waist - params.num_sig_long * self.sig_s + (slice_index + 0.5) * ds
+        self._pulse_pos = -params.num_sig_long * self.sig_s + (slice_index + 0.5) * ds
         self._wavefront(params, files)
 
     def _wavefront(self, params, files):
@@ -291,7 +292,7 @@ class LaserPulseSlice(ValidatorBase):
             return
         # calculate slice energy intensity (not energy associated with lambda)
         sliceEnInt = params.slice_params.pulseE*np.exp(-self._pulse_pos**2/(2*self.sig_s**2))
-        self.wfr = srwutil.createGsnSrcSRW(self.sigx_waist, self.sigy_waist, self.num_sig_trans, self._pulse_pos, sliceEnInt, params.slice_params.poltype, \
+        self.wfr = srwutil.createGsnSrcSRW(self.sigx_waist, self.sigy_waist, self.num_sig_trans, -self._pulse_pos + self.dist_waist, sliceEnInt, params.slice_params.poltype, \
                                            self.nx_slice, self.ny_slice, self.phE, params.slice_params.mx, params.slice_params.my)
 
 


### PR DESCRIPTION
Longitudinal position calculation `pulse_pos`, updated to no longer contain `dist_waist`.

`createGsnScrSRW()` in pulse.py now has correct argument to create pulse with waist at z = `dist_waist`