### PR TITLE
Fix #151: gain calc option for each propagator

### DIFF
--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -167,7 +167,7 @@ class CrystalSlice(Element):
                                 /(self.length *params.nslice)
 
 
-    def _propagate_attenuate(self, laser_pulse, with_gain_calc):
+    def _propagate_attenuate(self, laser_pulse, calc_gain):
         # n_x = wfront.mesh.nx  #  nr of grid points in x
         # n_y = wfront.mesh.ny  #  nr of grid points in y
         # sig_cr_sec = np.ones((n_x, n_y), dtype=np.float32)
@@ -181,14 +181,14 @@ class CrystalSlice(Element):
         raise NotImplementedError(f'{self}.propagate() with prop_type="attenuate" is not currently supported')
 
 
-    def _propagate_placeholder(self, laser_pulse, with_gain_calc):
+    def _propagate_placeholder(self, laser_pulse, calc_gain):
         # nslices = len(laser_pulse.slice)
         # for i in np.arange(nslices):
         #     print ('Pulse slice ', i+1, ' of ', nslices, ' propagated through crystal slice.')
         # return laser_pulse
         raise NotImplementedError(f'{self}.propagate() with prop_type="placeholder" is not currently supported')
 
-    def _propagate_n0n2_lct(self, laser_pulse, with_gain_calc):
+    def _propagate_n0n2_lct(self, laser_pulse, calc_gain):
         print('prop_type = n0n2_lct')
         nslices_pulse = len(laser_pulse.slice)
         L_cryst = self.length
@@ -221,7 +221,7 @@ class CrystalSlice(Element):
         for i in np.arange(nslices_pulse):
         # i = 0
             thisSlice = laser_pulse.slice[i]
-            if with_gain_calc:
+            if calc_gain:
                 thisSlice = self.calc_gain(thisSlice)
 
             # construct 2d numpy complex E_field from pulse wfr object
@@ -308,7 +308,7 @@ class CrystalSlice(Element):
         # return wfr1
         return laser_pulse
 
-    def _propagate_abcd_lct(self, laser_pulse, with_gain_calc):
+    def _propagate_abcd_lct(self, laser_pulse, calc_gain):
         print('prop_type = abcd_lct')
         nslices_pulse = len(laser_pulse.slice)
         l_scale = self.l_scale
@@ -336,7 +336,7 @@ class CrystalSlice(Element):
         for i in np.arange(nslices_pulse):
         # i = 0
             thisSlice = laser_pulse.slice[i]
-            if with_gain_calc:
+            if calc_gain:
                 thisSlice = self.calc_gain(thisSlice)
 
             # construct 2d numpy complex E_field from pulse wfr object
@@ -423,7 +423,7 @@ class CrystalSlice(Element):
         # return wfr1
         return laser_pulse
 
-    def _propagate_n0n2_srw(self, laser_pulse, with_gain_calc):
+    def _propagate_n0n2_srw(self, laser_pulse, calc_gain):
         print('prop_type = n0n2_srw')
         nslices = len(laser_pulse.slice)
         L_cryst = self.length
@@ -433,7 +433,7 @@ class CrystalSlice(Element):
 
         for i in np.arange(nslices):
             thisSlice = laser_pulse.slice[i]
-            if with_gain_calc:
+            if calc_gain:
                 thisSlice = self.calc_gain(thisSlice)
             #print(type(thisSlice))
 
@@ -474,7 +474,7 @@ class CrystalSlice(Element):
                 print('Propagated pulse slice ', i+1, ' of ', nslices)
         return laser_pulse
 
-    def _propagate_gain_test(self, laser_pulse, with_gain_calc):
+    def _propagate_gain_test(self, laser_pulse, calc_gain):
         #print('prop_type = gain_test (n0n2_srw)')
         nslices = len(laser_pulse.slice)
         L_cryst = self.length
@@ -525,7 +525,7 @@ class CrystalSlice(Element):
                 #print('Propagated pulse slice ', i+1, ' of ', nslices)
         return laser_pulse
 
-    def propagate(self, laser_pulse, prop_type, with_gain_calc=False):
+    def propagate(self, laser_pulse, prop_type, calc_gain=False):
         return PKDict(
             attenuate=self._propagate_attenuate,
             placeholder=self._propagate_placeholder,
@@ -534,7 +534,7 @@ class CrystalSlice(Element):
             n0n2_srw=self._propagate_n0n2_srw,
             gain_test=self._propagate_gain_test,
             default=super().propagate,
-        )[prop_type](laser_pulse, with_gain_calc)
+        )[prop_type](laser_pulse, calc_gain)
 
     # KW To Do: consider merging with _interpolate_pop_change()
     def _interpolate_pop_inversion(self, lp_wfr):

--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -484,13 +484,9 @@ class CrystalSlice(Element):
 
         for i in np.arange(nslices):
             thisSlice = laser_pulse.slice[i]
-            if with_gain_calc:
-                # TODO (gurhar1133): better way of defaulting differently for
-                # _propagate_gain_test
-
-                # Updates the self.n_photons_2d of the pulse wavefront
-                # and the self.pop_inversion_mesh values of the crystal slice
-                thisSlice = self.calc_gain(thisSlice)
+            # Updates the self.n_photons_2d of the pulse wavefront
+            # and the self.pop_inversion_mesh values of the crystal slice
+            thisSlice = self.calc_gain(thisSlice)
 
             if n2 == 0:
                 #print('n2 = 0')

--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -94,12 +94,9 @@ class Crystal(Element):
                 p.nslice = min(len(p.n0), len(p.n2))
         return p
 
-    def propagate(self, laser_pulse, prop_type='default'):
-        # TODO (gurhar1133): should this take laser_pulse and prop_type?
-        # also, should pass the same pulse through each slice and return
-        # the final pulse result?
+    def propagate(self, laser_pulse, prop_type, calc_gain=False):
         for s in self.slice:
-            laser_pulse = s.propagate(laser_pulse, prop_type)
+            laser_pulse = s.propagate(laser_pulse, prop_type, calc_gain)
         return laser_pulse
 
 

--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -474,55 +474,11 @@ class CrystalSlice(Element):
                 print('Propagated pulse slice ', i+1, ' of ', nslices)
         return laser_pulse
 
-    def _propagate_gain_test(self, laser_pulse, calc_gain):
-        #print('prop_type = gain_test (n0n2_srw)')
-        nslices = len(laser_pulse.slice)
-        L_cryst = self.length
-        n0 = self.n0
-        n2 = self.n2
-        #print('n0: %g, n2: %g' %(n0, n2))
-
-        for i in np.arange(nslices):
+    def _propagate_gain_calc(self, laser_pulse, calc_gain):
+        # calculates gain regardles of calc_gain param value
+        for i in np.arange(len(laser_pulse.slice)):
             thisSlice = laser_pulse.slice[i]
-            # Updates the self.n_photons_2d of the pulse wavefront
-            # and the self.pop_inversion_mesh values of the crystal slice
             thisSlice = self.calc_gain(thisSlice)
-
-            if n2 == 0:
-                #print('n2 = 0')
-                #A = 1.0
-                #B = L_cryst
-                #C = 0.0
-                #D = 1.0
-                optDrift = srwlib.SRWLOptD(L_cryst/n0)
-                propagParDrift = [0, 0, 1., 0, 0, 1., 1., 1., 1., 0, 0, 0]
-                #propagParDrift = [0, 0, 1., 0, 0, 1.1, 1.2, 1.1, 1.2, 0, 0, 0]
-                optBL = srwlib.SRWLOptC([optDrift],[propagParDrift])
-                #print("L_cryst/n0=",L_cryst/n0)
-            else:
-                #print('n2 .ne. 0')
-                gamma = np.sqrt(n2/n0)
-                A = np.cos(gamma*L_cryst)
-                B = (1/gamma)*np.sin(gamma*L_cryst)
-                C = -gamma*np.sin(gamma*L_cryst)
-                D = np.cos(gamma*L_cryst)
-                f1= B/(1-A)
-                L = B
-                f2 = B/(1-D)
-
-                optLens1 = srwlib.SRWLOptL(f1, f1)
-                optDrift = srwlib.SRWLOptD(L)
-                optLens2 = srwlib.SRWLOptL(f2, f2)
-
-                propagParLens1 = [0, 0, 1., 0, 0, 1, 1, 1, 1, 0, 0, 0]
-                propagParDrift = [0, 0, 1., 0, 0, 1, 1, 1, 1, 0, 0, 0]
-                propagParLens2 = [0, 0, 1., 0, 0, 1, 1, 1, 1, 0, 0, 0]
-
-                optBL = srwlib.SRWLOptC([optLens1,optDrift,optLens2],[propagParLens1,propagParDrift,propagParLens2])
-                #optBL = createABCDbeamline(A,B,C,D)
-
-                srwlib.srwl.PropagElecField(thisSlice.wfr, optBL) # thisSlice s.b. a pointer, not a copy
-                #print('Propagated pulse slice ', i+1, ' of ', nslices)
         return laser_pulse
 
     def propagate(self, laser_pulse, prop_type, calc_gain=False):
@@ -532,7 +488,7 @@ class CrystalSlice(Element):
             abcd_lct=self._propagate_abcd_lct,
             n0n2_lct=self._propagate_n0n2_lct,
             n0n2_srw=self._propagate_n0n2_srw,
-            gain_test=self._propagate_gain_test,
+            gain_calc=self._propagate_gain_calc,
             default=super().propagate,
         )[prop_type](laser_pulse, calc_gain)
 

--- a/tests/element_test.py
+++ b/tests/element_test.py
@@ -26,6 +26,7 @@ def test_crystal_nslice():
     with pykern.pkunit.pkexcept(element.ElementException, "you've specified"):
         crystal.Crystal(PKDict(nslice=51, n0=[1], n2=[1]))
 
+
 def crystal_slice_prop_test(prop_type):
     c = crystal.CrystalSlice()
     p = pulse.LaserPulse()


### PR DESCRIPTION
Now there's an optional keyword param calc_gain that when passed to propagate will determine if calc gain is applied

```python
def propagate(self, laser_pulse, prop_type, calc_gain=False):
```

`_propagate_gain_test()` will calculate gain regardless of value of param calc_gain however (is this what we want?) @bruhwiler @k-wolfinger ?
