### PR TITLE
add thermal stress to linear optics calculation

### DIFF
--- a/examples/wavefront/crystalMatrices_mech_stress01.ipynb
+++ b/examples/wavefront/crystalMatrices_mech_stress01.ipynb
@@ -1,0 +1,1380 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Linear Optics Phase Calculation for the BELLA Laser Experiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Boaz Nash, _RadiaSoft LLC_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Imports and definitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from IPython.display import Markdown, display\n",
+    "def printmd(string):\n",
+    "    display(Markdown(string))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$M_T = M_d \\bar M_c M_c^{-1} M_d^{-1}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Calculate alpha over range of n2 values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define n0\n",
+    "n0 = 1.76\n",
+    "#n2=1.6e-3 #cm^-2\n",
+    "#n2 = 16 #m^-2 from Fenics calculation\n",
+    "#n2 = 15.38\n",
+    "# n2 = 11.76\n",
+    "# n2 = 1.75\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rayleigh range[m] 6.637527140690282\n",
+      "sigma_theta[rad] 9.792803648444322e-05\n",
+      "Sigma matrix without pumping: [[4.22500000e-07 0.00000000e+00]\n",
+      " [0.00000000e+00 9.58990033e-09]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# define beam size, wavelength, and calculate initial moments\n",
+    "\n",
+    "#sigmax = 64e-6 #rms beam size [m]\n",
+    "#sigmax = 1e-3\n",
+    "w0=1.3e-3 #beamsize at WFS in [m] from the fit in data02\n",
+    "#sigma = 0.5 w0\n",
+    "sigmax = 0.5*w0\n",
+    "lambda_rad = 799.89e-9 #wavelength [m]\n",
+    "Zr = np.pi*w0**2/lambda_rad\n",
+    "sigtheta = lambda_rad/(4*np.pi*sigmax) #rms divergence [rad]\n",
+    "\n",
+    "sigmai = np.array( [[sigmax**2, 0], [0, sigtheta**2] ] ) \n",
+    "\n",
+    "print(\"Rayleigh range[m]\",Zr)\n",
+    "print(\"sigma_theta[rad]\",sigtheta)\n",
+    "print(\"Sigma matrix without pumping:\",sigmai)\n",
+    "# print(\"sigmaf:\",sigmaf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flen_front = 4.4 #measured front of crystal focal length from thermal bulging\n",
+    "flen_back = 6.2 #measured back of crystal focal length from thermal bulging\n",
+    "f = flen_back\n",
+    "\n",
+    "Lc = 0.025\n",
+    "#Ld = 0.5\n",
+    "Ld = 0.5\n",
+    "Matcinv = np.array( [[ 1, -Lc/n0], [0, 1]])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.99366141  0.00321452]\n",
+       " [-0.01249963  1.00633859]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 0.5, alpha: 0.0062525\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.98732319  0.00642886]\n",
+       " [-0.02499852  1.0126768 ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 1, alpha: 0.0125839\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.98098534  0.009643  ]\n",
+       " [-0.03749667  1.01901464]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 1.5, alpha: 0.0189958\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.97464787  0.01285695]\n",
+       " [-0.04999408  1.02535209]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 2, alpha: 0.0254897\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.96831076  0.01607072]\n",
+       " [-0.06249075  1.03168917]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 2.5, alpha: 0.032067\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.96197403  0.01928429]\n",
+       " [-0.07498668  1.03802587]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 3, alpha: 0.0387296\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.95563768  0.02249767]\n",
+       " [-0.08748188  1.04436219]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 3.5, alpha: 0.0454789\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.94930169  0.02571087]\n",
+       " [-0.09997633  1.05069814]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 4, alpha: 0.0523167\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.94296608  0.02892387]\n",
+       " [-0.11247004  1.05703371]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 4.5, alpha: 0.0592448\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.93663084  0.03213668]\n",
+       " [-0.12496301  1.0633689 ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 5, alpha: 0.0662649\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.93029597  0.0353493 ]\n",
+       " [-0.13745525  1.06970371]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 5.5, alpha: 0.0733789\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.92396148  0.03856173]\n",
+       " [-0.14994674  1.07603814]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 6, alpha: 0.0805886\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.91762736  0.04177398]\n",
+       " [-0.16243749  1.0823722 ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 6.5, alpha: 0.087896\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.91129361  0.04498603]\n",
+       " [-0.17492751  1.08870588]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 7, alpha: 0.095303\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.90496023  0.04819789]\n",
+       " [-0.18741678  1.09503918]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 7.5, alpha: 0.102812\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.89862722  0.05140956]\n",
+       " [-0.19990532  1.1013721 ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 8, alpha: 0.110424\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.89229459  0.05462104]\n",
+       " [-0.21239311  1.10770465]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 8.5, alpha: 0.118143\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.88596233  0.05783233]\n",
+       " [-0.22488017  1.11403682]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 9, alpha: 0.125969\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.87963044  0.06104343]\n",
+       " [-0.23736648  1.12036861]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 9.5, alpha: 0.133906\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.87329893  0.06425434]\n",
+       " [-0.24985206  1.12670002]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 10, alpha: 0.141956\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.86696778  0.06746506]\n",
+       " [-0.2623369   1.13303106]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 10.5, alpha: 0.150121\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.86063701  0.07067559]\n",
+       " [-0.274821    1.13936172]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 11, alpha: 0.158403\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.85430661  0.07388593]\n",
+       " [-0.28730436  1.145692  ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 11.5, alpha: 0.166806\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.84797659  0.07709608]\n",
+       " [-0.29978698  1.1520219 ]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 12, alpha: 0.175331\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.84164693  0.08030604]\n",
+       " [-0.31226886  1.15835143]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 12.5, alpha: 0.183982\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.83531765  0.08351581]\n",
+       " [-0.32475     1.16468057]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 13, alpha: 0.192761\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.82898874  0.08672539]\n",
+       " [-0.3372304   1.17100935]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 13.5, alpha: 0.201671\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.8226602   0.08993478]\n",
+       " [-0.34971006  1.17733774]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 14, alpha: 0.210716\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.81633204  0.09314398]\n",
+       " [-0.36218899  1.18366575]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 14.5, alpha: 0.219897\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.81000424  0.09635299]\n",
+       " [-0.37466717  1.18999339]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 15, alpha: 0.229218\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.80367682  0.09956181]\n",
+       " [-0.38714461  1.19632065]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 15.5, alpha: 0.238682\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.79734978  0.10277044]\n",
+       " [-0.39962132  1.20264753]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 16, alpha: 0.248294\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.7910231   0.10597888]\n",
+       " [-0.41209729  1.20897404]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 16.5, alpha: 0.258055\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.7846968   0.10918712]\n",
+       " [-0.42457251  1.21530017]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 17, alpha: 0.267969\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.77837086  0.11239518]\n",
+       " [-0.437047    1.22162592]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 17.5, alpha: 0.278041\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.7720453   0.11560305]\n",
+       " [-0.44952075  1.22795129]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 18, alpha: 0.288274\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.76572012  0.11881073]\n",
+       " [-0.46199376  1.23427629]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 18.5, alpha: 0.298671\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.7593953   0.12201822]\n",
+       " [-0.47446603  1.24060091]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 19, alpha: 0.309237\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.75307086  0.12522552]\n",
+       " [-0.48693756  1.24692515]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 19.5, alpha: 0.319976\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "$M_{ABCD}$: [[ 0.74674679  0.12843263]\n",
+       " [-0.49940835  1.25324901]]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n2: 20, alpha: 0.330891\n"
+     ]
+    }
+   ],
+   "source": [
+    "# define array of n2 values and calculate corresponding alpha values\n",
+    "\n",
+    "n_n2 = 40\n",
+    "n2_min = 0.5\n",
+    "n2_max = 20\n",
+    "n2_vals = np.linspace(n2_min, n2_max, n_n2)\n",
+    "\n",
+    "alpha_vals = []\n",
+    "\n",
+    "for n2 in n2_vals:\n",
+    "\n",
+    "    \n",
+    "    gamma = np.sqrt(n2/n0)\n",
+    "    A = np.cos(gamma*Lc)\n",
+    "    B = 1/(n0 * gamma) * np.sin(gamma*Lc)\n",
+    "    C = -n0 * gamma * np.sin(gamma * Lc)\n",
+    "    D = np.cos(gamma*Lc)\n",
+    "    Matcbar = np.array( [[ A, B], [C, D]] )\n",
+    "    Matd = np.array( [[ 1, Ld], [0, 1]] )\n",
+    "    Matdinv = np.array( [[ 1, -Ld], [0, 1]] )\n",
+    "    Mat_tl = np.array( [[ 1, 0], [-1/f, 1]] )\n",
+    "    Mat_tl_front = np.array( [[ 1, 0], [-1/flen_front, 1]] )\n",
+    "    Mat_tlinv = np.array( [[ 1, 0], [1/f, 1]] )\n",
+    "    MatId = np.array( [[1, 0], [0, 1]] )\n",
+    "    Mattot0 = np.matmul(np.matmul(np.matmul(Matd,Matcbar),Matcinv),Matdinv)\n",
+    "    #Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl),Matcbar),Matcinv),Mat_tlinv),Matdinv)\n",
+    "    #Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl),Matcbar),Matcinv),Mat_tl),Matdinv)\n",
+    "    Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl),Matcbar),Mat_tl_front),Matcinv),Mat_tl),Matdinv)\n",
+    "\n",
+    "    # print(gamma)\n",
+    "    # print(Mattot0)\n",
+    "    printmd('$M_{ABCD}$: %s' %(Mattot0))\n",
+    "    Mattot = Mattot0\n",
+    "    \n",
+    "    sigmaf = np.matmul(np.matmul(Mattot, sigmai),np.transpose(Mattot))\n",
+    "    \n",
+    "    alpha = -0.5* sigmaf[0,1]/sigmaf[0,0]\n",
+    "    print('n2: %g, alpha: %g' %(n2, alpha))\n",
+    "    \n",
+    "    alpha_vals.append(alpha)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Calculate alpha via overall ABCD matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "det(ABCD): 1\n",
+      "alpha_abcd: 0.176284\n"
+     ]
+    }
+   ],
+   "source": [
+    "# define ABCD matrix from values calculated by multiplying component ABCD matrices in thermal simulation [cm]\n",
+    "# A = 9.99685237e-01\n",
+    "# B = 1.42040659 / 1e2        # divide by 1e2 to convert cm to m\n",
+    "# C = -3.20164929e-04 * 1e2    # multiply by 1e2 to convert 1/cm to 1/m\n",
+    "# D = 9.99859955e-01\n",
+    "\n",
+    "# from thermal simulation (K_c = 0.33 [W/cm/K], standard BELLA params) \n",
+    "A = 9.98822400e-01\n",
+    "B = 1.42013835 / 1e2\n",
+    "C = -1.19776239e-03 * 1e2\n",
+    "D = 9.99475995e-01\n",
+    "\n",
+    "# # from thermal simulation (K_c = 0.14 [W/cm/K], standard BELLA params - yields alpha_pi in agreement with alpha_pi_JVT) \n",
+    "# A = 0.99721995\n",
+    "# B = 1.41960963 / 1e2\n",
+    "# C = -0.00282665 * 1e2\n",
+    "# D = 0.99876387\n",
+    "\n",
+    "# A = 0.99765495\n",
+    "# B = 1.41975385 / 1e2\n",
+    "# C = -0.0023775 * 1e2\n",
+    "# D = 0.99896716\n",
+    "\n",
+    "# A = 0.97544003\n",
+    "# B = 0.01245522\n",
+    "# C = -0.04843195\n",
+    "# D = 1.02455993\n",
+    "\n",
+    "print('det(ABCD): %g' %(A*D - B*C))\n",
+    "\n",
+    "flen_front = 5                       # focal length [m] of lens at crystal entrance face\n",
+    "flen_back = flen_front / 12          # focal length [m] of lens at crystal end face\n",
+    "\n",
+    "Matcbar = np.array( [[ A, B], [C, D]] )                       # propagation through crystal with focusing\n",
+    "Matd = np.array( [[ 1, Ld], [0, 1]] )                         # drift (distance between crystal and wfs)\n",
+    "Matdinv = np.array( [[ 1, -Ld], [0, 1]] )                     # inverse drift (distance between crystal and wfs)\n",
+    "Mat_tl_back = np.array( [[ 1, 0], [-1/flen_back, 1]] )        # thin lens due to mech stress at crystal end face\n",
+    "Mat_tl_front = np.array( [[ 1, 0], [-1/flen_front, 1]] )      # thin lens due to mech stress at crystal entrance face\n",
+    "Mat_tl_back_inv = np.array( [[ 1, 0], [1/flen_back, 1]] )           # inverse of thin lens due to mech stress at crystal end face\n",
+    "MatId = np.array( [[1, 0], [0, 1]] )                          # identity matrix\n",
+    "Mattot0 = np.matmul(np.matmul(np.matmul(Matd,Matcbar),Matcinv),Matdinv)\n",
+    "#Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl),Matcbar),Matcinv),Mat_tlinv),Matdinv)\n",
+    "#Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl),Matcbar),Matcinv),Mat_tl),Matdinv)\n",
+    "Mattot1 = np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(np.matmul(Matd,Mat_tl_back),Matcbar),Mat_tl_front),Matcinv),Mat_tl_back_inv),Matdinv)\n",
+    "\n",
+    "# print(gamma)\n",
+    "# print(Mattot0)\n",
+    "Mattot = Mattot1\n",
+    "\n",
+    "sigmaf = np.matmul(np.matmul(Mattot, sigmai),np.transpose(Mattot))\n",
+    "\n",
+    "alpha_abcd = -0.5* sigmaf[0,1]/sigmaf[0,0]\n",
+    "print('alpha_abcd: %g' %(alpha_abcd))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Calculate alpha via complex beam parameter, q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(-2.476591024703272+0.9248405310713015j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Compute initial q\n",
+    "lambda_rad = 799.89e-9 #wavelength [m]\n",
+    "lambdabar = lambda_rad/(2*np.pi)\n",
+    "k = 1/lambdabar\n",
+    "w0 = 1.64e-3 #beamsize at WFS in [m]\n",
+    "sigmar = 0.5*w0\n",
+    "q0 = 1j*np.pi*w0**2/lambda_rad\n",
+    "A = Mattot[0,0]\n",
+    "B = Mattot[0,1]\n",
+    "C = Mattot[1,0]\n",
+    "D = Mattot[1,1]\n",
+    "qf = (A*q0 + B)/(C*q0 + D)\n",
+    "print(qf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_q: 0.177182\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf = k*np.real(1/qf)\n",
+    "alpha_q = -lambda_rad * bf/(4*np.pi)\n",
+    "print('alpha_q: %g' %alpha_q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsMAAAI6CAYAAADCEUWTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAA9hAAAPYQGoP6dpAABf5klEQVR4nO3deVxU9f7H8feAAq6kUSBKblhmLpgLWWneJNE2zTK1crumLWYaWWo3NbWbZVZmmktplrfM6qZtZilCWpGW+5KGXbdJAbUAxQRjzu+P8xMbWQRm4Awzr+fjMQ+cM2e+fGYa8N3X7/l+bIZhGAIAAAB8kJ/VBQAAAABWIQwDAADAZxGGAQAA4LMIwwAAAPBZhGEAAAD4LMIwAAAAfBZhGAAAAD6LMAwAAACfVcnqAioih8Ohw4cPq0aNGrLZbFaXAwAAgPMYhqETJ04oPDxcfn6Fz/8Shkvh8OHDioiIsLoMAAAAXMChQ4dUr169Qh8nDJdCjRo1JJlvbs2aNS2uBgAAAOfLzMxUREREXm4rDGG4FM4ujahZsyZhGAAAwINdaEkrF9ABAADAZxGGAQAA4LMIwwAAAPBZhGEAAAD4LMIwAAAAfBZhGAAAAD6LMAwAAACfRRgGAACAzyIMAwAAwGcRhgEAAOCzCMMAAADwWYRhAAAA+CzCMAAAAHwWYRgAAAA+izAMAAAAn0UYBgAAgM8iDAMAAMBnEYYBAABQtux2KSHB/OphCMMAAAAoOwsWSPXrSzfeaH5dsMDqipwQhgEAAFA27HZp2DDJ4TDvOxzSAw941AwxYRgAAABlIzn5XBA+KzdX2rvXmnoKQBgGAABA2di1K/8xf38pMrL8aykEYRgAAADu99ln0qhR0rXXmgFYMr/OmyfVq2dpaX9XyeoCAAAA4GXWrJF695Zuv11aulRKSTGXRkRGelQQlgjDAAAAcKcffjBDcOfO0nvvSZUqmQHYw0LwWSyTAAAAgHts3Sp17y5dfbX08cdSYKDVFV0QYRgAAACu++UXqWtXqVEjc71w1apWV1QshGEAAAC45sABKSZGCgmRvvpKCg62uqJiIwwDAACg9FJSzCBcubK0apUZiCsQLqADAABA6fz+u3TTTdKpU9K330rh4VZXVGKEYQAAAJTciRNSt27mzPDatVLDhlZXVCqEYQAAAJTMn39Kt90m7dkjJSRIV15pdUWlxpphAAAAFI/dLn39tXTrrdKPP0orVpjbqFVgzAwDAADgwhYskIYNkxwO8/5jj0nXXWdtTW7AzDAAAACKZrc7B2FJmjnTPF7BEYYBAABQtF9+cQ7CkpSbK+3da009bkQYBgAAQOEMQ/rww/zH/f2lyMjyr8fNCMMAAAAo3OTJ0ty5Ut++ZgCWzK/z5kn16llbmxsQhgEAAFCwadOkZ56RnntOWrJE2r/f3Ept/35pyBCLi3MPdpMAAABAfrNmSWPGSE8/LY0bZx6rV88rZoP/jplhAAAAOFu4UBoxQoqLM5dJeDHCMAAAAM5ZskS6/37pwQel6dMlm83qisoUYRgAAACmZcuk/v2lAQOk2bO9PghLhGEAAABI0pdfSn36SHfdZXab8/ONmOgbrxIAAACFW7NG6tVL6t5dWrz43BZqPoAwDAAA4Mu+/166/XapUydp6VKpcmWrKypXhGEAAABftXGjORvcpo25XjgoyOqKyh1hGAAAwNfY7ea64JgY6corpc8/l6pWtboqS9B0AwAAwJcsWCANGyY5HOb9e++VatSwtiYLMTMMAADgK+x25yAsSY89Zh73UYRhAAAAX7FunXMQlqTcXGnvXmvq8QCEYQAAAF9gt0tjxuQ/7u8vRUaWfz0egjAMAADg7Q4flm680ewo98IL5/YR9veX5s2T6tWztj4LcQEdAACAN0tNlbp0kU6dktaulRo1ku65x1waERnp00FYIgwDAAB4r2PHzO3TMjKkb74xg7BkBmAfD8FnEYYBAAC80e+/SzfdJKWlSYmJUpMmVlfkkQjDAAAA3iY9XeraVTp0yAzCV15pdUUeizAMAADgTTIzzRbL//uftGaN1Ly51RV5NMIwAACAtzh5UrrlFmnXLik+XoqKsroij+fxW6vNnj1bDRo0UFBQkKKjo7Vhw4ZCz/3444/Vtm1bXXTRRapWrZqioqK0ePFip3MMw9CECRNUp04dValSRTExMUpOTi7rlwEAAFC2Tp2SbrtN2rJF+uorqW1bqyuqEDw6DC9dulRxcXGaOHGiNm3apFatWik2NlZpaWkFnl+7dm3961//UlJSkrZt26bBgwdr8ODB+uqrr/LOmTZtmmbOnKm5c+dq/fr1qlatmmJjY3X69OnyelkAAADudfq01LOntGGD9OWX0jXXWF1RhWEzDMOwuojCREdHq127dpo1a5YkyeFwKCIiQiNGjNDYsWOLNcbVV1+tW265RVOmTJFhGAoPD9fjjz+u0aNHS5IyMjIUGhqqRYsWqW/fvsUaMzMzU8HBwcrIyFDNmjVL9+IAAADcITtb6tXLXB+8YoX0j39YXZFHKG5e89iZ4ZycHG3cuFExMTF5x/z8/BQTE6OkpKQLPt8wDMXHx2vPnj3q1KmTJGnfvn1KSUlxGjM4OFjR0dFFjpmdna3MzEynGwAAgKXsdunrr82lEfHx0iefEIRLwWMvoDt27Jhyc3MVGhrqdDw0NFS7d+8u9HkZGRmqW7eusrOz5e/vr9dff1033XSTJCklJSVvjPPHPPtYQaZOnapJkyaV9qUAAAC414IF0rBhksNh3n/0UXMrNZSYx84Ml1aNGjW0ZcsW/fjjj/r3v/+tuLg4JSYmujTmuHHjlJGRkXc7dOiQe4oFAAAoKbvdOQhL0uzZ5nGUmMfODIeEhMjf31+pqalOx1NTUxUWFlbo8/z8/BQZGSlJioqK0s8//6ypU6eqc+fOec9LTU1VnTp1nMaMKmLrkcDAQAUGBrrwagAAANxk927nICxJubnS3r20WC4Fj50ZDggIUJs2bRQfH593zOFwKD4+Xh06dCj2OA6HQ9nZ2ZKkhg0bKiwszGnMzMxMrV+/vkRjAgAAWCI3V3r99fzH/f2l/58MRMl47MywJMXFxWngwIFq27at2rdvrxkzZigrK0uDBw+WJA0YMEB169bV1KlTJZlre9u2bavGjRsrOztbK1as0OLFizVnzhxJks1m06hRo/Tss8+qSZMmatiwocaPH6/w8HD17NnTqpcJAABwYbm50uDB0qefSg88IL35pnnM31+aN49Z4VLy6DDcp08fHT16VBMmTFBKSoqioqK0cuXKvAvgDh48KD+/c5PbWVlZevjhh2W321WlShU1bdpU//nPf9SnT5+8c5588kllZWVp2LBhSk9P1/XXX6+VK1cqKCio3F8fAABAseTmSkOGSO++a9769pWeftpcGhEZSRB2gUfvM+yp2GcYAACUG4dDuv9+6e23pcWLpXvusbqiCqHC7zMMAADg8xwOc+eIt9+W3nmHIFwGPHqZBAAAgM9yOMy1wQsXmmH43nutrsgrMTMMAADgaRwO6aGHzOYab70l9e9vdUVeizAMAADgSQxDGj5ceuMNMwwPHGh1RV6NZRIAAACewjCkRx6R5s41t077/+1kUXaYGQYAAPAEhiE9+qjZVGP+fHMrNZQ5ZoYBAACsZLdLv/xi7h+8cKHZQGPoUKur8hmEYQAAAKssWGBuneZwmPfvu8+8j3LDMgkAAAAr2O3OQViSliwxj6PcEIYBAACs8MsvzkFYMtsu791rTT0+ijAMAABQ3gxDeu+9/Mf9/aXIyPKvx4cRhgEAAMqTYUijRpnrhe+91wzAkvl13jypXj1Ly/M1hGEAAIDycnb7tJkzpTlzpP/8R9q/X0pIML+ynVq5YzcJAACA8nC2ocbrr5szwGd3jahXj9lgCxGGAQAAyprDYQbhOXPMNsv33291Rfh/hGEAAICy5HBIDz9sdpVbsED65z+trgh/QxgGAAAoKw6H9OCD0ptvmkF48GCrK8J5CMMAAABlweGQHnjADMFvvSUNHGh1RSgAYRgAAMDdHA5p6FAzBC9aJA0YYHVFKARhGAAAwJ1yc80L5N55x7zdd5/VFaEIhGEAAAB3yc019wpevNgMwvfea3VFuADCMAAAgKvsdmn3bnPrtOXLzWYa/fpZXRWKgTAMAADgigULzAYaDod5f9gwgnAFQjtmAACA0rLbnYOwZIZju926mlAihGEAAIDS+vln5yAsmeuG9+61ph6UGGEYAACgNLKzpenT8x/395ciI8u/HpQKYRgAAKCkTp+WevWSvvlGevRRMwBL5td586R69aytD8XGBXQAAAAlceqU1LOntG6d9Nln0k03SU88YS6NiIwkCFcwhGEAAIDiysqSbrtNWr9eWrFC+sc/zOP16hGCKyjCMAAAQHGcOCHdcou0ebO0cqXUsaPVFcENCMMAAAAXkpEhde8u7dwprVolXXON1RXBTQjDAAAARfnjDyk2VkpOluLjpbZtra4IbkQYBgAAKMyxY1LXrtLBg9KaNVLr1lZXBDcjDAMAABQkLU2KiZFSUqSEBKlFC6srQhkgDAMAAJzvyBGpSxdziURiotSsmdUVoYzQdAMAAOAsu1364APpuuukzEyzqQZB2KsxMwwAACBJCxZIw4ZJDod5/7nnpMsvt7YmlDlmhgEAAOx25yAsSePHm8fh1QjDAAAA8fHOQViScnPNFsvwaoRhAADg27Zvlx5/PP9xf38pMrL860G5IgwDAADftXGj1LmzFBEhvfKKGYAl8+u8eVK9epaWh7LHBXQAAMA3ff+92WL5yiulL7+UatWS7rrLXBoRGUkQ9hGEYQAA4HsSE6Vbb5XatJE+/1yqUcM8Xq8eIdjHsEwCAAD4lq++MmeEr73WnBE+G4ThkwjDAADAd3zyiXT77dJNN0mffipVrWp1RbAYYRgAAPiGpUulO++UevSQPvpICgqyuiJ4AMIwAADwfosWSffcY97ee08KCLC6IngIwjAAAPBuc+ZIgwdL999vhuJK7B+AcwjDAADAe73yivTww9Kjj0pz50p+RB8443+NAACAd7HbpeRkc6eIF1+Uxo2T/v1vyWazujJ4IMIwAADwHgsWSMOGSQ6Heb9nT+m55ywtCZ6NfysAAADewW53DsKS9Nln5nGgEIRhAADgHXbvdg7CkpSba7ZXBgpBGAYAABVfTo706qv5j/v7S5GR5V8PKgzCMAAAqNj+/FPq1Uv6+mtz5wh/f/O4v780b55Ur5619cGjcQEdAACouE6cMNsrr19vrg/u2tXcPWLvXnNGmCCMCyAMAwCAiun336Xu3c21wl9/LV1/vXm8Xj1CMIqNMAwAACqe1FRzFvi336Q1a6Q2bayuCBUUYRgAAFQsBw9KMTHSyZPSN99IV11ldUWowDz+ArrZs2erQYMGCgoKUnR0tDZs2FDouW+88YY6duyoWrVqqVatWoqJicl3/qBBg2Sz2Zxu3bp1K+uXAQAA3CE5WerYUTpzRlq3jiAMl3l0GF66dKni4uI0ceJEbdq0Sa1atVJsbKzS0tIKPD8xMVH9+vVTQkKCkpKSFBERoa5du+q3335zOq9bt246cuRI3m3JkiXl8XIAAIArtm83g3CVKmYQbtzY6orgBWyGYRhWF1GY6OhotWvXTrNmzZIkORwORUREaMSIERo7duwFn5+bm6tatWpp1qxZGjBggCRzZjg9PV3Lly8vdV2ZmZkKDg5WRkaGatasWepxAABAMf34o9Stm3TZZdJXX0mXXmp1RfBwxc1rHjsznJOTo40bNyomJibvmJ+fn2JiYpSUlFSsMU6dOqUzZ86odu3aTscTExN16aWX6oorrtBDDz2k48ePFzlOdna2MjMznW4AAKCM2e1SQoL00UdSly7SFVeY9wnCcCOPDcPHjh1Tbm6uQkNDnY6HhoYqJSWlWGOMGTNG4eHhToG6W7dueueddxQfH68XXnhB33zzjbp3767c3NxCx5k6daqCg4PzbhEREaV7UQAAoHgWLJDq15duvFHq3dvcKu3rr6WLLrK6MngZr91N4vnnn9f777+vxMREBQUF5R3v27dv3p9btGihli1bqnHjxkpMTFSXLl0KHGvcuHGKi4vLu5+ZmUkgBgCgrNjt0rBhksNx7tgvv0jp6VL16paVBe/ksTPDISEh8vf3V2pqqtPx1NRUhYWFFfnc6dOn6/nnn9fXX3+tli1bFnluo0aNFBISor179xZ6TmBgoGrWrOl0AwAAZSQ52TkIS1JurtlVDnAzjw3DAQEBatOmjeLj4/OOORwOxcfHq0OHDoU+b9q0aZoyZYpWrlyptm3bXvD72O12HT9+XHXq1HFL3QAAwEUJCfmP+fub7ZUBN/PYMCxJcXFxeuONN/T222/r559/1kMPPaSsrCwNHjxYkjRgwACNGzcu7/wXXnhB48eP18KFC9WgQQOlpKQoJSVFJ0+elCSdPHlSTzzxhH744Qft379f8fHx6tGjhyIjIxUbG2vJawQAAP/PMKSnn5amTJFuvtkMwJL5dd48WiyjTHj0muE+ffro6NGjmjBhglJSUhQVFaWVK1fmXVR38OBB+fmdy/Nz5sxRTk6O7rrrLqdxJk6cqGeeeUb+/v7atm2b3n77baWnpys8PFxdu3bVlClTFBgYWK6vDQAA/I3DIY0YIb3+ujRtmvTEE+ba4b17zRlhgjDKiEfvM+yp2GcYAAA3OnNGGjRIWrJEmj9fuv9+qyuCFyhuXvPomWEAAODl/vxTuvtus5HG0qXmNmpAOSIMAwAAa2RmSrffbnaX++wziet3YAHCMAAAKH9Hj5rtlX/9VVq1Srr2Wqsrgo8iDAMAgPJ16JDUtav0xx/SN99IrVpZXRF8GGEYAACUn19+kW66SbLZpHXrpCZNrK4IPs6j9xkGAABeZMsWqWNHqVo16bvvCMLwCMwMAwCAsmO3m+2V//hDGjxYuvxy6csvpZAQqysDJBGGAQBAWVmwQBo2zGyoIUlXXCHFx0vs0Q8PwjIJAADgfna7cxCWzG5ymZnW1QQUgDAMAADcLznZOQhLUm6uGYgBD0IYBgAA7mUYZhON8/n7S5GR5V8PUATCMAAAcB+HQxoxQnrlFalXLzMAS+bXefOkevWsrQ84DxfQAQAA98jJkQYMkD78UHrjDen++821w3v3mjPCBGF4IMIwAABw3cmT0p13SomJZhju1cs8Xq8eIRgejTAMAABcc/y4dMst0q5d0sqV0j/+YXVFQLERhgEAQOkdOiTFxkrHjpmzwldfbXVFQImUKgx/+umnJX7OTTfdpCpVqpTm2wEAAE+0e7fUtavk5yd9+63ZXQ6oYEoVhnv27Fmi8202m5KTk9WoUaPSfDsAAOBpfvxR6t5dCguTvvpKqlvX6oqAUin11mopKSlyOBzFulWtWtWdNQMAACutXm2uC778cmntWoIwKrRSzQwPHDiwREse7rvvPtWkDzkAABWX3W52lduzR3r0USkmxtw1olo1qysDXGIzDMOwuoiKJjMzU8HBwcrIyCDkAwC834IF0rBh59orR0dL69ZJlStbWxdQhOLmNTrQAQCAwtntzkFYkn76SUpNta4mwI3cFobXr1/vrqEAAICn2L3bOQhLUm6u2VUO8AJuC8O9e/d211AAAMATnD4tvfJK/uP+/mZ7ZcALlOgCurvvvrvA44Zh6Pfff3dLQQAAwANkZEg9e0o//CANHy7NnWvOCPv7S/Pm0WIZXqNEYXj16tVavHixqlev7nTcMAytXbvWrYUBAACLHDli7iF84IC0apV0/fXS2LHm0ojISIIwvEqJwnDnzp1Vo0YNderUKd9jLVu2dFtRAADAIsnJZle5M2fMHSOaNzeP16tHCIZXYmu1UmBrNQCAV/rxR+nmm6WQELOr3GWXWV0RUGrlsrVaSkqKK08HAACe4quvzK5ykZHSt98ShOEzXArDXbt2dVcdAADAKu++K916q9S5sxQfL118sdUVAeXGpTDMCgsAACq4l1+W7rvPvC1bJlWtanVFQLlyKQzbbDZ31QEAAMqTwyE9+aT0+OPSuHHSwoW0V4ZPKtFuEgAAoAKz283dIho0kCZOlBYvlmbMkEaOtLoywDKEYQAAfMGCBdKwYedaK/v7S0uWSH37WlsXYDGXlkn4+/u7qw4AAFBW7HbnICxJhmE20wB8nEthePPmze6qAwAAlJXkZOcgLJn39+61ph7Ag7gUhgEAQAXw55/5j/n7m3sKAz7O5TXDmZmZeuutt5SSkqKGDRuqVatWatGihaqyNQsAANZbuVK6+26pYUPp4EEpN9cMwvPm0V4ZkBvCcK9evbR161a1a9dOn332mfbs2SNJaty4sVq1aqWlS5e6XCQAACiFRYukoUOlbt2k99+X/vjDXBoRGUkQBv6fy2E4KSlJiYmJateunSQpOztb27dv15YtW7R161aXCwQAACVkGNJzz0lPP22G4ddflypVkqpVIwQD53E5DLds2VKVKp0bJjAwUG3btlXbtm1dHRoAAJRUbq70yCPS3LnSpEnS+PESTbKAQrl8Ad20adM0YcIEZWdnu6MeAABQWqdOSXfeKb3xhvTmm9KECQRh4AJcnhlu0KCBMjMz1axZM/Xp00fXXHONWrdurYiICHfUBwAAiuP4cem226StW6VPPpFuucXqioAKweWZ4TvvvFP79+/Xddddp++//14DBw5UgwYNdMkll6hr167uqBEAABRl3z7puuvM/YQTEgjCQAm4PDO8Y8cOJSUlqVWrVnnH9u/fr82bN2vbtm2uDg8AAIqyebN0883mxXFJSewdDJSQy2G4Xbt2ysrKcjrWoEEDNWjQQHfccYerwwMAgPPZ7eYs8JEj0gMPSE2bSl98IV16qdWVARWOy8skRo4cqWeeeUbp6eluKAcAABRpwQKpfn3pxhule++VGjQwl0YQhIFSsRmGYbgygJ+fmacvvvhi3XHHHYqOjlbr1q3VvHlzBQQEuKVIT5OZmang4GBlZGSoZs2aVpcDAPAVdrsZhB2Oc8f8/aX9+9k/GDhPcfOay8sk9u3bp61bt+Y12Xjuuee0f/9+VapUSVdccQXrhgEAcJfdu52DsGTuK7x3L2EYKCWXw3D9+vVVv3593X777XnHTpw4oS1bthCEAQBwl5MnpalT8x/39+eiOcAFLq8ZPnToUL5jNWrUUMeOHTV8+HBXhwcAACkpUufO0oYN0qhRZgCWzK/z5jErDLjALTPDtWvXVqtWrRQVFZV3y8nJ0cyZM/X222+7o04AAHzT7t1S9+7S6dPS2rVS69bS44+bSyMiIwnCgIvcsmZ48+bN2rJlizZv3qwPPvhAhw8fliQuLgMAwBXr1kk9ekh16kiJiebFc5IZgAnBgFu4bc1wz549844lJSVp4MCBmjx5sqvDAwDgmz74QOrfX7r2Wunjj6VatayuCPBKLq8ZLkiHDh306quvavr06WUxPAAA3sswpOnTpT59pLvuklauJAgDZcjlMJyTk1Pg8SZNmmjnzp2uDg8AgO/IzZUefVR64glp3Dhp8WIpMNDqqgCv5vIyierVq6tZs2Zq3bq1oqKi1Lp1a4WHh+u1115TTEyMO2oEAMD7nTol3XOP9Nln0ty5ZptlAGXO5Q503377rbZu3ZrXeGPHjh06ffq0JKlbt25q27atWrRooRYtWqhp06ZuKdpqdKADALhVWpp0223Sjh3mWuFbbrG6IqDCK25eczkMn8/hcGjPnj3asmVLXle6rVu3Ki0tTbm5ue78VpYhDAMA3MJul9askcaPN7dO++ILqW1bq6sCvEJx85rbL6Dz8/PTlVdeqX79+umFF17QypUrdeTIkbzt1kpq9uzZatCggYKCghQdHa0NGzYUeu4bb7yhjh07qlatWqpVq5ZiYmLynW8YhiZMmKA6deqoSpUqiomJUXJycqlqAwCg1BYsMLdKGzhQOnhQeuwxgjBggVKF4W3btslxfm/0IuzcuVMXX3xxib/P0qVLFRcXp4kTJ2rTpk1q1aqVYmNjlZaWVuD5iYmJ6tevnxISEpSUlKSIiAh17dpVv/32W94506ZN08yZMzV37lytX79e1apVU2xsbN7SDgAAypzdLg0dKv3979KnnzaPAyhXpVom4e/vr5SUFF1yySXFOr9mzZrasmWLGjVqVKLvEx0drXbt2mnWrFmSzCUYERERGjFihMaOHXvB5+fm5qpWrVqaNWuWBgwYIMMwFB4erscff1yjR4+WJGVkZCg0NFSLFi1S3759i1UXyyQAAKVmGNKDD0rz5+d/LCHBbLsMwGXFzWul2k3CMAyNHz9eVatWLdb5hW2/dqHnbNy4UePGjcs75ufnp5iYGCUlJRVrjFOnTunMmTOqXbu2JLNbXkpKitMuF8HBwYqOjlZSUlKhYTg7O1vZ2dl59zMzM0v8egAA0F9/SY88YgZhm80Mxmf5+5vtlQGUq1KF4U6dOmnPnj3FPr9Dhw6qUqVKib7HsWPHlJubq9DQUKfjoaGh2r17d7HGGDNmjMLDw/PCb0pKSt4Y54959rGCTJ06VZMmTSpJ+QAAODtxQrr7bmnVKunNN81jDzxg7i3s7y/Nm0eLZcACpQrDiYmJbi7D/Z5//nm9//77SkxMVFBQkEtjjRs3TnFxcXn3MzMzFRER4WqJAABfYbdLt94q7dsnffmldNNN5vHYWGnvXnNGmCAMWMLlphtlJSQkRP7+/kpNTXU6npqaqrCwsCKfO336dD3//PNavXq1WrZsmXf87PNSU1NVp04dpzGjoqIKHS8wMFCBdAACAJTGli3mvsH+/tJ330nNm597rF49QjBgMbdvreYuAQEBatOmjeLj4/OOORwOxcfHq0OHDoU+b9q0aZoyZYpWrlyptudtUdOwYUOFhYU5jZmZman169cXOSYAAKWyYoXUsaMUFiatX+8chAF4BI+dGZakuLg4DRw4UG3btlX79u01Y8YMZWVlafDgwZKkAQMGqG7dupo6daok6YUXXtCECRP03nvvqUGDBnnrgKtXr67q1avLZrNp1KhRevbZZ9WkSRM1bNhQ48ePV3h4uHr27GnVywQAeKM5c8yL5W65RVqyRKpWzeqKABTAo8Nwnz59dPToUU2YMEEpKSmKiorSypUr8y6AO3jwoPz8zk1uz5kzRzk5Obrrrrucxpk4caKeeeYZSdKTTz6prKwsDRs2TOnp6br++uu1cuVKl9cVAwAgydw7eMwYafp06dFHpZdfNpdIAPBILrdj7tmzpyZPnuy0Ntfbsc8wAKBAf/4p9e8vffyx9Mor0siRVlcE+Kxya8d88803684771Tv3r21a9euvOMHDx7UVVdd5erwAAB4NrvdbJaxZYv0j3+Yu0UsW0YQBioIl5dJtGnTRs2aNdOyZcu0bNkytW/fXlWrVtWuXbsUHh7ujhoBAPBMCxZIw4ada6tcs6b0zTfSeRdwA/BcLofh/v3768orr9SSJUtUqVIl7d69Wy+99JIaNmyor7/+2h01AgDgeex25yAsSVlZ5s4RACoMl9cMV61aVdu3b1fjxo3zjv3++++65557VK9ePb15tsuOF2HNMABACQnSjTcWfLxz53IvB4CzclszHB0drU8++cTpWO3atfXqq69qyZIlrg4PAIDncTjMi+TO5+9vdpMDUGG4HIZfeOEFPf300xo8eLDWr1+vnJwcnTlzRh999JGqsaciAMDb/Pmn1LevNHu21Lv3uW3T/P2lefPoKAdUMC6vGW7fvr3WrFmjxx9/XB06dJDNZpO/v7/++usvTZkyxR01AgDgGVJTpR49pG3bpP/+V7rjDnPt8N695owwQRiocFxeM/x3v/32m37++WdlZGQoKirKaR2xN2HNMAD4oB07pFtvlXJypM8+k9q0sboiAEUobl5zawe6unXrqm7duu4cEgAA6331lbkkolEj6fPPmQEGvIjLa4YBAPBqc+ZIt9wi3XCD9O23BGHAyxCGAQAoSG6u9Nhj0sMPSyNGSMuXS9WrW10VADdz6zIJAAC8wsmTUr9+Zmvl2bPNQAzAKxGGAQCQzF0hkpPN2d9hw6RffzXXB3frZnVlAMoQYRgAgAULnFsr164tff+91Ly5tXUBKHNlumbYz89PN954ozZu3FiW3wYAgNKz252DsCRlZEgXXWRZSQDKT5mG4YULF6pTp04aPnx4WX4bAABK75dfnIOwZF48t3evNfUAKFdubbrhK2i6AQBeIjtb6t9f+vBD5+P+/tL+/WyjBlRgxc1rbpkZXrdune677z516NBBv/32myRp8eLF+vbbb90xPAAA7nfsmHTTTdInn0hDhpgBWDK/zptHEAZ8hMth+L///a9iY2NVpUoVbd68WdnZ2ZKkjIwMPffccy4XCACA2+3aJbVvL+3ZIyUmSm++ac4EJySYX4cMsbhAAOXF5TD87LPPau7cuXrjjTdUuXLlvOPXXXedNm3a5OrwAAC418qVUocO5hZqGzaYf5bMmeDOnZkRBnyMy2F4z5496tSpU77jwcHBSk9Pd3V4AADcwzCk114zWyt36iR9951Uv77VVQGwmMthOCwsTHsLuOL222+/VaNGjVwdHgAA1505Iw0fLj36qNlieflyqUYNq6sC4AFcbroxdOhQjRw5UgsXLpTNZtPhw4eVlJSk0aNHa/z48e6oEQCA0vvjD+nuu8+tDWY9MIC/cTkMjx07Vg6HQ126dNGpU6fUqVMnBQYGavTo0RoxYoQ7agQAoHSSk6VbbzV3jli1ylwTDAB/47Z9hnNycrR3716dPHlSzZo1U/Xq1d0xrEdin2EAqAASEqQ775QuvVT6/HMpMtLqigCUo3LZZ/jMmTPq0qWLkpOTFRAQoGbNmql9+/ZeHYQBAB7MbjdD8LRpUteuUps2UlISQRhAoVxaJlG5cmVt27bNXbUAAFB6CxZIw4ada63cubO0YoX0t20/AeB8Lu8mcd9992nBggXuqAUAgNKx252DsCStWyelplpXE4AKweUL6P766y8tXLhQq1evVps2bVStWjWnx19++WVXvwUAAEVLTHQOwpKUmyvt3UsTDQBFcjkM79ixQ1dffbUk6ZdffnF6zGazuTo8AABFW7NGKmj3In9/1goDuCCXw3BCQoI76gAAoORef91spHHjjeYWanFx5oywv780bx6zwgAuyOUwDABAuTtzRho5UpozxwzDL70kVaok9eplLo2IjCQIAygWl8Pw5MmTi3x8woQJrn4LAADOOX5c6t3bvEBu/nxp6NBzj9WrRwgGUCIuh+Fly5Y53T9z5oz27dunSpUqqXHjxoRhAID77Nol3X67lJ4urV4t3XCD1RUBqOBcDsObN2/OdywzM1ODBg3SHXfc4erwAACYVqyQ+vaV6tc3Wys3bGh1RQC8gMv7DBekZs2amjRpksaPH18WwwMAfIlhSNOnmxfIde4sff89QRiA25RJGJakjIwMZWRklNXwAABfkJ0tDR4sPfGENGaMtGyZVKOG1VUB8CIuL5OYOXOm033DMHTkyBEtXrxY3bt3d3V4AIAvstul9eul556Tdu6UFi+W7rvP6qoAeCGXw/Arr7zidN/Pz0+XXHKJBg4cqHHjxrk6PADA1yxY4Nxa+amnCMIAyozNMAzDlQEOHDigiIgI+fk5r7gwDEOHDh3SZZdd5lKBnigzM1PBwcHKyMhQzZo1rS4HALyH3S5ddpm5Tvgsf39p/362TANQIsXNay6vGW7UqJGOHTuW7/jvv/+uhlzgAAAoLodDGjfOOQhLZke5vXutqQmA13N5mURhE8snT55UUFCQq8MDAHxBZqbUv7/06aeSzZZ/Zjgy0rraAHi1UofhuLg4SZLNZtOECRNUtWrVvMdyc3O1fv16RUVFuVwgAMDL/fqr2UjDbpc+/1xKSZEeeMCcEfb3l+bNY4kEgDJT6jB8ttmGYRjavn27AgIC8h4LCAhQq1atNHr0aNcrBAB4r9WrpbvvlkJCpB9+kK680jweG2sujYiMJAgDKFOlDsMJCQmSpMGDB+vVV1/lQjIAQPEZhvTqq9Ljj0s33SQtWSLVqnXu8Xr1CMEAyoXLF9C99dZbBGEAQPFlZ0v//Kf02GNmGP7iC+cgDADlyOUL6M7atWuXDh48qJycHKfjt99+u7u+BQCgojtyROrVS9q8mUYaADyCy2H4f//7n+644w5t375dNpstb3cJm80mybyYDgAAbdgg3XGH+ed166R27aytBwDkhmUSI0eOVMOGDZWWlqaqVatq586dWrt2rdq2bavExEQ3lAgAqJDsdikhwfy6eLHUqZNUv770008EYQAew+WZ4aSkJK1Zs0YhISHy8/OTn5+frr/+ek2dOlWPPvpo3q4TAAAf8veWymf3Df7nP6XXX5cCA62uDgDyuDwznJubqxo1akiSQkJCdPjwYUlS/fr1tWfPHleHBwBUNHb7uSAsmUHYZpOeeYYgDMDjuDwz3Lx5c23dulUNGzZUdHS0pk2bpoCAAM2fP1+NGjVyR40AgIokOflcED7LMMzmGhER1tQEAIVwOQw//fTTysrKkiRNnjxZt956qzp27KiLL75YS5cudblAAEAFs3dv/mO0VAbgoVwOw7GxsXl/joyM1O7du/X777+rVq1aeTtKAAB8gMMhTZwoPfus1LatuX0aLZUBeDiX1wzff//9+XaNqF27NkEYAHxJRobUo4f0739Lzz9vbqO2f7+5m8T+/dKQIVZXCAAFcnlm+OjRo+rWrZsuueQS9e3bV/fee6+ioqLcUBoAoEL4+WepZ08pLU1asULq1s08TktlABWAyzPDn3zyiY4cOaLx48frxx9/VJs2bXTVVVfpueee0/79+91QIgDAY336qRQdLVWuLP3447kgDAAVhM042zLOTex2u5YsWaKFCxcqOTlZf/31lzuH9wiZmZkKDg5WRkaGatasaXU5AFD+HA5pyhRzu7RevaRFi6T/32YTADxBcfOay8sk/u7MmTP66aeftH79eu3fv1+hoaHuHB4A4AkyM6UBA8xZ4WeflcaNk/xc/odGALCEW357JSQkaOjQoQoNDdWgQYNUs2ZNff7557Lb7S6PPXv2bDVo0EBBQUGKjo7Whg0bCj13586duvPOO9WgQQPZbDbNmDEj3znPPPOMbDab061p06Yu1wkAPuGXX8xlEQkJ0mefSf/6F0EYQIXm8sxw3bp19fvvv6tbt26aP3++brvtNgW6qcPQ0qVLFRcXp7lz5yo6OlozZsxQbGys9uzZo0svvTTf+adOnVKjRo3Uu3dvPfbYY4WOe9VVV2n16tV59ytVcusEOQB4F7vdbKRx8KD06KNSeLi5W8QVV1hdGQC4zOUU+Mwzz6h379666KKL3FCOs5dffllDhw7V4MGDJUlz587VF198oYULF2rs2LH5zm/Xrp3atWsnSQU+flalSpUUFhbm9noBwOssWODcWrlVK2ntWonrJQB4CZf+bevMmTN6//33dfToUXfVkycnJ0cbN25UTExM3jE/Pz/FxMQoKSnJpbGTk5MVHh6uRo0a6d5779XBgweLPD87O1uZmZlONwDwena7cxCWpB07zDXDAOAlXArDlStX1rZt29xVi5Njx44pNzc330V4oaGhSklJKfW40dHRWrRokVauXKk5c+Zo37596tixo06cOFHoc6ZOnarg4OC8W0RERKm/PwBUGPHxzkFYMjvKFdRuGQAqKJeverjvvvu0YMECd9RSLrp3767evXurZcuWio2N1YoVK5Senq4PPvig0OeMGzdOGRkZebdDhw6VY8UAYIFPP5UeeST/cX9/KTKy/OsBgDLi8prhv/76SwsXLtTq1avVpk0bVatWzenxl19+uVTjhoSEyN/fX6mpqU7HU1NT3bre96KLLtLll1+uvUXMdAQGBrrtokAA8GgOh7l38JQp5v7BN94ojRxpzgj7+0vz5tFVDoBXcTkM79ixQ1dffbUk6ZdffnF6zGazlXrcgIAAtWnTRvHx8erZs6ckyeFwKD4+Xo8UNFtRSidPntSvv/6q/v37u21MAKiQ/vhDuu8+6csvpeeek8aOlWw2qUcPc2lEZCRBGIDXcTkMJyQkuKOOAsXFxWngwIFq27at2rdvrxkzZigrKytvd4kBAwaobt26mjp1qiTzortdu3bl/fm3337Tli1bVL16dUX+/z/rjR49Wrfddpvq16+vw4cPa+LEifL391e/fv3K7HUAgMfbvl264w7p99+llSulrl3PPVavHiEYgNfy6A12+/Tpo6NHj2rChAlKSUlRVFSUVq5cmXdR3cGDB+X3t83eDx8+rNatW+fdnz59uqZPn64bbrhBiYmJksx20f369dPx48d1ySWX6Prrr9cPP/ygSy65pFxfGwB4jPffl4YMkZo0kVatkho2tLoiACg3NsMwDFcGmDx5cpGPT5gwwZXhPVJxe10DgEf76y9zKcRLL0n33ivNny9VrWp1VQDgFsXNay7PDC9btszp/pkzZ7Rv3z5VqlRJjRs39sowDAAV3tGjUp8+ZgONV1+VRoww1wcDgI9xOQxv3rw537HMzEwNGjRId9xxh6vDAwDc4WxL5SZNpCNHpDvvlLKzpTVrpE6drK4OACzj8jKJwmzfvl233Xab9u/fXxbDW4plEgAqlL+3VLbZzC3S2rSRPvqIC+MAeK3i5jWXm24U5myDCgCAhc5vqWwY5p7B775LEAYAuWGZxMyZM53uG4ahI0eOaPHixerevburwwMAXJGcnL+lsmFIhw5JjRtbUxMAeBCXw/Arr7zidN/Pz0+XXHKJBg4cqHHjxrk6PADAFWlp+Y/RUhkA8rgchvft2+eOOgAA7mQY0osvSuPGSVdeKf3yCy2VAaAALq8Znjp1qhYuXJjv+MKFC/XCCy+4OjwAoKQyM83dIsaMMfcR3r5d2r9fSkgwvw4ZYnWFAOAxXA7D8+bNU9OmTfMdv+qqqzR37lxXhwcAlMTOnVK7dlJ8vLR8ufTvf5uzwfXqSZ07MyMMAOdxOQynpKSoTp06+Y5fcsklOnLkiKvDAwCK6/33pfbtpYAA6aefpB49rK4IADyey2E4IiJC3333Xb7j3333ncLDw10dHgBwIWfOSI89JvXrJ/XsKf3wg9lcAwBwQS5fQDd06FCNGjVKZ86c0Y033ihJio+P15NPPqnHH3/c5QIBAEU4ckS6+24zAL/2mjR8OG2VAaAEXA7DTzzxhI4fP66HH35YOTk5kqSgoCCNGTOGrdUAoCytW2cGYT8/6ZtvpGuvtboiAKhw3NaO+eTJk/r5559VpUoVNWnSRIGBge4Y1iPRjhmAZex2c5u0tWulZ5+Vrr/eXCscFmZ1ZQDgUYqb11yeGT6revXqateunbuGAwCcb8EC59bKsbHS559Lldz2qxwAfI7LF9ABAMqB3e4chCVp9WopJcW6mgDACxCGAaAimD/fOQhLZke5vXutqQcAvAT/tgYAniwnR3riCWnmzPyP+ftLkZHlXxMAeBHCMAB4qkOHzN0iNm6UZs2SAgOlBx80Z4T9/aV58+goBwAucksYXrdunebNm6dff/1VH330kerWravFixerYcOGuv76693xLQDAt6xaJd1zj1SlirmFWnS0ebxbN3NpRGQkQRgA3MDlNcP//e9/FRsbqypVqmjz5s3Kzs6WJGVkZOi5555zuUAA8CkOhzRlirlTxNVXS5s2nQvCkhmAO3cmCAOAm7gchp999lnNnTtXb7zxhipXrpx3/LrrrtOmTZtcHR4AfMfx49Ktt0oTJ0oTJkgrVkghIVZXBQBezeVlEnv27FGnTp3yHQ8ODlZ6erqrwwOAb/jxR+muu6SsLOnLL82ZYQBAmXN5ZjgsLEx7C9ja59tvv1WjRo1cHR4AvJthSHPmmJ3kwsLMZREEYQAoNy6H4aFDh2rkyJFav369bDabDh8+rHfffVejR4/WQw895I4aAcC72O1SQoLZVrl/f+nhh6WhQ80Wy5ddZnV1AOBTXF4mMXbsWDkcDnXp0kWnTp1Sp06dFBgYqNGjR2vEiBHuqBEAvMf5LZUDAqT33pP69bO2LgDwUTbDMAx3DJSTk6O9e/fq5MmTatasmapXr+6OYT1SZmamgoODlZGRoZo1a1pdDoCKwm6X6td37iTn5ycdOMDuEADgZsXNay4vk/jzzz916tQpBQQEqFmzZgoNDdWbb76pr7/+2tWhAcC77NyZv6Wyw0FLZQCwkMthuEePHnrnnXckSenp6YqOjtZLL72kHj16aM6cOS4XCABeYd8+6ckn8x+npTIAWMrlMLxp0yZ17NhRkvTRRx8pNDRUBw4c0DvvvKOZM2e6XCAAVHiffmo20DhxQnr6aTMAS7RUBgAP4PIFdKdOnVKNGjUkSV9//bV69eolPz8/XXPNNTpw4IDLBQJAhXXmjPTUU9L06VKPHtJbb0m1akkPPEBLZQDwEC7PDEdGRmr58uU6dOiQvvrqK3Xt2lWSlJaWxsVlAHyX3S794x/SjBnSSy9Jy5aZQViipTIAeBCXw/CECRM0evRoNWjQQNHR0erQoYMkc5a4devWLhcIABXO119LrVubu0R8840UFyfZbFZXBQAogFu2VktJSdGRI0fUqlUr+fmZ+XrDhg2qWbOmmjZt6nKRnoat1QAUKDdXmjRJevZZqWtX6T//kUJCrK4KAHxScfOay2uGJbMlc1hYmNOx9u3bu2NoAKgYUlOle+6REhOlKVOkcePMPYQBAB7NLWFYknbt2qWDBw8qJyfH6fjtt9/urm8BAJ7FbpeSk6Xjx6VHHzX3DF692lwrDACoEFwOw//73/90xx13aPv27bLZbDq76sL2/+vjcnNzXf0WAOB5zm+rfPnl5qxwnTqWlgUAKBmX/w1v5MiRatiwodLS0lS1alXt3LlTa9euVdu2bZWYmOiGEgHAw9jtzkFYkn791VwzDACoUFwOw0lJSZo8ebJCQkLk5+cnPz8/XX/99Zo6daoeffRRd9QIAJ7l44/zt1XOzaWtMgBUQC6H4dzc3LymGyEhITp8+LAkqX79+tqzZ4+rwwOA53A4pOeflx57LP9jtFUGgArJ5TXDzZs319atW9WwYUNFR0dr2rRpCggI0Pz589WoUSN31AgA1jt6VBowQFq50twpokED6eGHzRlh2ioDQIXlchh++umnlZWVJUmaPHmybr31VnXs2FEXX3yxli5d6nKBAGC5deukfv2k7Gzpyy+lbt3M4zffTFtlAKjg3NJ043y///67atWqlbejhLeh6QbgIxwO6YUXpPHjpWuvlZYskerWtboqAEAxFDevlcmO8LVr1/baIAzARxw9as78/utf0tix0po1BGEA8EJuaboRHx+v+Ph4paWlyXHeFdYLFy50x7cAgPKzdq25LOLMGXONcNeuVlcEACgjLs8MT5o0SV27dlV8fLyOHTumP/74w+kGABWGwyH9+99mB7kmTaQtWwjCAODlXJ4Znjt3rhYtWqT+/fu7ox4AKH92u7Rhg/Tqq+bFck8/LU2YIFVyW8d6AICHcvk3fU5Ojq699lp31AIA5e/8tspxcdLkydbWBAAoNy4vk7j//vv13nvvuaMWAChfBw5IQ4c6d5N79VVzphgA4BNKNTMcFxeX92eHw6H58+dr9erVatmypSpXrux07ssvv+xahQBQFg4flnr2lM7fXfJsW2X2DQYAn1CqMLx582an+1FRUZKkHTt2OB1nezUAHmnlSrObnJ+fefv7zDBtlQHAp5QqDCckJBR4/Gz/DkIwAI905oy5b/CLL0rdu0tvvy19+qn0wAO0VQYAH+WWphsLFixQ8+bNFRQUpKCgIDVv3lxvvvmmO4YGAPfYv1/q2FF65RUzDH/+uXTJJdKQIeZjCQnm1yFDLC4UAFCeXN5NYsKECXr55Zc1YsQIdejQQZKUlJSkxx57TAcPHtRkrsoGYLX//tcMubVqSd9+K0VHOz9erx6zwQDgo2yGcf7VIyVzySWXaObMmerXr5/T8SVLlmjEiBE6duyYSwV6ouL2ugZgsdOnza3S5syR7rpLeuMN6aKLrK4KAFAOipvXXJ4ZPnPmjNq2bZvveJs2bfTXX3+5OjwAlM7u3VKfPtKePWYYfuABiesZAADncXnNcP/+/TVnzpx8x+fPn697773X1eEBoHjsdnPdr91uXhjXtq2Uk2N2lnvwQYIwAKBAbuk1umDBAn399de65pprJEnr16/XwYMHNWDAAKc9idlzGECZOL+LnCQNGiTNmiVVq2ZZWQAAz+fymuF//OMfxftGNpvWrFnjyrfyGKwZBjyI3S7Vr+8chP38zO5yXBQHAD6r3NYMF7bnsLvMnj1bL774olJSUtSqVSu99tprat++fYHn7ty5UxMmTNDGjRt14MABvfLKKxo1apRLYwLwcL/84hyEJfM+XeQAAMXgln2Gy8rSpUsVFxeniRMnatOmTWrVqpViY2OVlpZW4PmnTp1So0aN9PzzzyssLMwtYwLwYMeOSc89l/84XeQAAMXk0WH45Zdf1tChQzV48GA1a9ZMc+fOVdWqVbVw4cICz2/Xrp1efPFF9e3bV4GBgW4ZE4CHSkiQWrWStmyRRowwA7BEFzkAQIl4bBjOycnRxo0bFRMTk3fMz89PMTExSkpKKtcxs7OzlZmZ6XQDYJEzZ6Snn5a6dJGuuELatk2aOZMucgCAUvHYMHzs2DHl5uYqNDTU6XhoaKhSUlLKdcypU6cqODg47xYREVGq7w/ARfv3SzfcID3/vPTss9KqVVJ4uPlYvXpS587MCAMASsRjw7AnGTdunDIyMvJuhw4dsrokwPd8+KEUFSUdPiytWyc99dS5pREAAJSSW/YZLgshISHy9/dXamqq0/HU1NRCL44rqzEDAwMLXYMMoIxlZUmjRklvvindfbe5HpiWygAAN/HYmeGAgAC1adNG8fHxecccDofi4+PVoUMHjxkTQBnats3sJPfuu2YYfv99gjAAwK08dmZYkuLi4jRw4EC1bdtW7du314wZM5SVlaXBgwdLkgYMGKC6detq6tSpkswL5Hbt2pX3599++01btmxR9erVFfn/2yxdaEwAFrPbzb2Dv//eXBd8xRXSxo3SlVdaXRkAwAt5dBju06ePjh49qgkTJiglJUVRUVFauXJl3gVwBw8elJ/fucntw4cPq3Xr1nn3p0+frunTp+uGG25QYmJiscYEYKHz2yrfeKP0xRdSUJC1dQEAvJbL7Zh9Ee2YgTJQUFtlf39zBwl2iAAAlFBx85rHrhkG4EPOnJHGjMnfVjk312yrDABAGfHoZRIAfMDevdI990ibNkk2m/T3f6yirTIAoIwxMwzAGoYhvf221Lq19McfUlKS9MYbtFUGAJQrZoYBlL/0dOmhh8yt0gYNMtsp16ghtWsnxcaas8WRkQRhAECZIwwDKF/ffSfde685G7xkidS3r/Pj9eoRggEA5YZlEgDKx19/SZMmSZ06SXXrSlu35g/CAACUM2aGAZS9/ful++4z1wVPmCD9619SJX79AACsx99GANzPbpeSk6UmTaRvv5UeeECqVUtau1a67jqrqwMAIA9hGIB7/b2L3Nmt0vr0kebOlS66yOrqAABwwpphAO5jtzu3UzYMyc9PevFFgjAAwCMRhgG4z+7d+bvIORzSr79aUw8AABdAGAbgHvv3S089lf84XeQAAB6MMAzAde++K7VqJaWlSU8+SRc5AECFwQV0AEovPV16+GGzeca990qzZ0vBwdKIEXSRAwBUCIRhAKWzdq3Uv78ZiN99V7rnnnOP0UUOAFBBsEwCQMnk5Jhrgzt3lurXNzvJ/T0IAwBQgTAzDKD49uwxl0Ns3So9+6w0Zsy59cEAAFRAhGEAhTvbSS4yUlq5Uho1SqpbV/r+e6ldO6urAwDAZYRhAAX7eye5s4YOlV5+Wape3bq6AABwI9YMA8jv/E5yktlJbsIEgjAAwKsQhgHkt2NHwZ3k9u61ph4AAMoIYRiAs02bzH2Cz0cnOQCAFyIMAzDl5kpTp0rR0eZSiMmT6SQHAPB6XEAHQNq3TxowQPruO3O7tEmTpIAAafBgOskBALwaYRjwZYYhvfOOuSyidm3pm2+kjh3PPU4nOQCAl2OZBOCrjh+XeveWBg2SevWStm1zDsIAAPgAZoYBX/TVV+YSiOxs6aOPpDvvtLoiAAAswcww4O3sdikhwfx66pS5JKJbN6llS2n7doIwAMCnMTMMeLO/d5Hz85MuvVRKT5dee00aPlyy2ayuEAAASxGGAW91fhc5h0NKSZHWrJH+8Q9rawMAwEOwTALwVsnJ+bvIScwGAwDwN4RhwBsZhrR+ff7jdJEDAMAJYRjwNkeOSLfcIo0bJ3XqRBc5AACKwJphwJt8+KH04INS5crS55+bodhup4scAACFIAwD3uCPP8wt0959V7rrLmnOHCkkxHyMLnIAABSKMAxUdKtWmQ00Tp6UFi+W7r2Xi+QAACgm1gwDFdXZBhpdu0pNm5oNNO67jyAMAEAJMDMMVBR2u7ldWpMm0uHDUv/+0sGD0quvSo88YjbVAAAAJUIYBiqCv3eSOzvz26aNtHmzOSsMAABKhTAMeLrzO8kZhhmIP/hAatjQ2toAAKjg+HdVwNPt2ZO/k5xhSAcOWFMPAABehDAMeLL//U/617/yH6eTHAAAbkEYBjyRYZjd4lq2lFJTpdGj6SQHAEAZYM0w4Gl++00aMkT66itp6FDppZekGjWkkSPpJAcAgJsRhgFPYRhmB7kRI6QqVaQVK6Tu3c89Tic5AADcjmUSgCdISzPbKPfvL91yi7Rjh3MQBgAAZYKZYcBqy5ZJDzxgzgx/+KEZigEAQLlgZhgoT3a7lJBgfk1PN2eCe/WSrr3WnA0mCAMAUK6YGQbKy9+7yPn5STVrmrPBb79thuKzneUAAEC5IQwD5eH8LnIOhzkzvH691L69paUBAODLWCYBlIfk5Pxd5CTp1KnyrwUAAOQhDANlLStLWrw4/3G6yAEAYDnCMFCW1q2TWrWS3n9f6tuXLnIAAHgYwjBQFk6dkuLipBtukMLCpK1bpSVLpP37zd0k9u83u8wBAABLcQEd4G5JSdKgQdLBg9L06WYb5bMzwnSRAwDAozAzDLjL6dPSk09K118v1aolbd5szg6fDcIAAMDjMDMMuMOGDdLAgdL//idNnSo9/jghGACACoAwDJSG3W5ul3bZZWYzjRdekK6+2pwNbtbM6uoAAEAxEYaBkvp7JznJnAGeMsVcIlGJHykAACoSj18zPHv2bDVo0EBBQUGKjo7Whg0bijz/ww8/VNOmTRUUFKQWLVpoxYoVTo8PGjRINpvN6datW7eyfAnwJud3kpPMlsoDBhCEAQCogDw6DC9dulRxcXGaOHGiNm3apFatWik2NlZpaWkFnv/999+rX79+GjJkiDZv3qyePXuqZ8+e2rFjh9N53bp105EjR/JuS5YsKY+XA2/w+ef5O8k5HNLevdbUAwAAXGIzDMOwuojCREdHq127dpo1a5YkyeFwKCIiQiNGjNDYsWPznd+nTx9lZWXp888/zzt2zTXXKCoqSnPnzpVkzgynp6dr+fLlpa4rMzNTwcHBysjIUM2aNUs9DiqQ7Gxp8mTp+efzh2F/f3PfYLZMAwDAYxQ3r3nszHBOTo42btyomJiYvGN+fn6KiYlRUlJSgc9JSkpyOl+SYmNj852fmJioSy+9VFdccYUeeughHT9+vMhasrOzlZmZ6XSDD/nxR/PiuBdflCZNMjvH0UkOAACv4LGLHI8dO6bc3FyFhoY6HQ8NDdXu3bsLfE5KSkqB56ekpOTd79atm3r16qWGDRvq119/1VNPPaXu3bsrKSlJ/oVshTV16lRNmjTJxVeECuf0aemZZ8wQ3Lq1tHGj1KKF+djNN5tLIyIjCcIAAFRgHhuGy0rfvn3z/tyiRQu1bNlSjRs3VmJiorp06VLgc8aNG6e4uLi8+5mZmYqIiCjzWmGhH36QBg829w1+9lnpiSecL5CjkxwAAF7BY5dJhISEyN/fX6mpqU7HU1NTFRYWVuBzwsLCSnS+JDVq1EghISHaW8QFUIGBgapZs6bTDV7qzz/N4HvddVKNGtKmTdK4cewUAQCAl/LYMBwQEKA2bdooPj4+75jD4VB8fLw6dOhQ4HM6dOjgdL4krVq1qtDzJclut+v48eOqU6eOewpHxfX991JUlPTaa2YXue+/l666yuqqAABAGfLo6a64uDgNHDhQbdu2Vfv27TVjxgxlZWVp8ODBkqQBAwaobt26mjp1qiRp5MiRuuGGG/TSSy/plltu0fvvv6+ffvpJ8+fPlySdPHlSkyZN0p133qmwsDD9+uuvevLJJxUZGanY2FjLXicsZLdL27dLy5ZJb74ptW8vLV8uXXml1ZUBAIBy4NFhuE+fPjp69KgmTJiglJQURUVFaeXKlXkXyR08eFB+fucmt6+99lq99957evrpp/XUU0+pSZMmWr58uZo3by5J8vf317Zt2/T2228rPT1d4eHh6tq1q6ZMmaLAwEBLXiMsdH4nud69pSVLzu0UAQAAvJ5H7zPsqdhn2Avs2WPO/v79489+wQAAeI0Kv88wUGZWr5ZuuME5CEtSbi6d5AAA8DGEYfiOjAxp6FDpppukhg0lv/M+/v7+5r7BAADAZxCG4Rs+/1xq1kxaulSaO1f67jtp/nw6yQEA4OM8+gI6wGXHjkmjRknvvit1724G3rMNU4YMkWJj6SQHAIAPIwzDOxmG9NFH0vDh0l9/SW+/LfXvL9lszufRSQ4AAJ/GMgl4n5QU6c47pbvvljp2lHbtkgYMyB+EAQCAz2NmGBWf3S4lJ5tLHRISzGURlStLH34o3XWX1dUBAAAPRhhGxXZ+4wxJuu8+acYM6eKLLSsLAABUDCyTQMVlt+cPwn5+0tSpBGEAAFAshGFUXGvWOAdhybxP4wwAAFBMhGFUPGfOSM8/bzbQOB+NMwAAQAkQhlGxbNoktW8v/etf0siR0uuv0zgDAACUGhfQoWL4809p0iRp+nTpqquk9eultm3Nx267jcYZAACgVAjD8Hxr10r33y8dOGAG4iefNLdOO4vGGQAAoJRYJgHPlZEhPfigdMMN0qWXSlu3mssj/h6EAQAAXMDMMDzH2eYZTZpImzdLDz1kBuLZs81Q7Mf/uwEAAPciDMMzFNQ8o3t3ae5c6bLLrKsLAAB4NcIwrFdY84x586SICOvqAgAAXo9/d4b11q4tuHnGr79aUw8AAPAZhGFY56+/pJdfloYMyf8YzTMAAEA5IAzDGlu2SNdcI40ebS6RmDWL5hkAAKDcsWYY5evUKXOv4Jdekpo1k5KSpOho87EePWieAQAAyhVhGOUnPl564AHzgrnJk6UnnqB5BgAAsBTLJFD2jh+XBg+WYmLMsLttm/TUUzTPAAAAlmNmGGXHMKSlS6VHH5VycqQ33pD++U+aZwAAAI9BGIZ7ne0iV7WquRRixQrprrukmTOlOnWsrg4AAMAJYRjuc34XuYsukj75RLr9dkvLAgAAKAz/Xg33KKiL3IkT0tVXW1cTAADABRCG4bpTp8z9gs/vIpeba26VBgAA4KEIw3DNV19JzZtLy5ZJNpvzY3SRAwAAHo4wjNJJTZXuuUfq1k1q2FDascPcLYIucgAAoALhAjqUjGFICxeaDTP8/KS335b69zdnhZs0kWJj6SIHAAAqDMIwim/3brOD3Nq10oABZkvlkBDnc+giBwAAKhCWSeDCsrOlSZOkVq2kw4el1avNGeHzgzAAAEAFw8wwCna2ecbx49L48ebShzFjpH/9S6pSxerqAAAA3IIwjPzOb57RuLG0ebO5awQAAIAXIQzD2aFD0tCh5oVyZ+3fb3aTAwAA8DKsGcY5yclSz57OQViieQYAAPBahGGYF8hNmSK1aCGlpdE8AwAA+AzCsK/75htzl4jJk6XHHpP27KF5BgAA8BmsGfZVx46ZjTMWLZKuu0766KNzF8gNGULzDAAA4BMIw77GMMwA/MQT5m4Rb7wh/fOfZje5v6N5BgAA8AEsk/AlP/8sde5sht/u3c2Ocvffnz8IAwAA+Ahmhr3Z2cYZ9epJ77wjvfCC1KCB2UGuSxerqwMAALAcYdhbnd84w99fevppaexYKSjI2toAAAA8BP8+7o3sducgLJlrhe+/nyAMAADwN4Rhb5ObK02b5hyEJfM+jTMAAACcsEzCm/z0k/Tgg9LGjWbjjL93kqNxBgAAQD7MDHuD9HRp+HCpfXtzZviHH2icAQAAUAzMDFdkhiG99570+ONSVpb0yitmKK5USYqOpnEGAADABRCGK6o9e6SHH5bWrJF69zaDcN26zufQOAMAAKBILJOoaP78Uxo/XmrZUjpwQPryS+mDD/IHYQAAAFwQM8MVwdnmGXa79Mwz5texY81blSpWVwcAAFBhEYY93fnNM668Utq+Xbr8cmvrAgAA8AIsk/BkBTXP+OUXqWpV62oCAADwIoRhT5acnL95Rm4uzTMAAADchDDsyZo0kfzO+09E8wwAAAC3IQx7snr1pPnzaZ4BAABQRriAztMNGULzDAAAgDLi8TPDs2fPVoMGDRQUFKTo6Ght2LChyPM//PBDNW3aVEFBQWrRooVWrFjh9LhhGJowYYLq1KmjKlWqKCYmRsnJyWX5ElxXr57UuTNBGAAAwM08OgwvXbpUcXFxmjhxojZt2qRWrVopNjZWaWlpBZ7//fffq1+/fhoyZIg2b96snj17qmfPntqxY0feOdOmTdPMmTM1d+5crV+/XtWqVVNsbKxOnz5dXi8LAAAAHsJmGIZhdRGFiY6OVrt27TRr1ixJksPhUEREhEaMGKGxY8fmO79Pnz7KysrS559/nnfsmmuuUVRUlObOnSvDMBQeHq7HH39co0ePliRlZGQoNDRUixYtUt++fYtVV2ZmpoKDg5WRkaGaNWu64ZUCAADAnYqb1zx2ZjgnJ0cbN25UTExM3jE/Pz/FxMQoKSmpwOckJSU5nS9JsbGxeefv27dPKSkpTucEBwcrOjq60DElKTs7W5mZmU43AAAAVHweG4aPHTum3NxchYaGOh0PDQ1VSkpKgc9JSUkp8vyzX0sypiRNnTpVwcHBebeIiIgSvx4AAAB4Ho8Nw55k3LhxysjIyLsdOnTI6pIAAADgBh4bhkNCQuTv76/U1FSn46mpqQoLCyvwOWFhYUWef/ZrScaUpMDAQNWsWdPpBgAAgIrPY8NwQECA2rRpo/j4+LxjDodD8fHx6tChQ4HP6dChg9P5krRq1aq88xs2bKiwsDCnczIzM7V+/fpCxwQAAID38uimG3FxcRo4cKDatm2r9u3ba8aMGcrKytLgwYMlSQMGDFDdunU1depUSdLIkSN1ww036KWXXtItt9yi999/Xz/99JPmz58vSbLZbBo1apSeffZZNWnSRA0bNtT48eMVHh6unj17WvUyAQAAYBGPDsN9+vTR0aNHNWHCBKWkpCgqKkorV67MuwDu4MGD8vM7N7l97bXX6r333tPTTz+tp556Sk2aNNHy5cvVvHnzvHOefPJJZWVladiwYUpPT9f111+vlStXKigoqNxfHwAAAKzl0fsMeyr2GQYAAPBsFX6fYQAAAKCsEYYBAADgswjDAAAA8FmEYQAAAPgswjAAAAB8FmEYAAAAPsuj9xn2VGd3o8vMzLS4EgAAABTkbE670C7ChOFSOHHihCQpIiLC4koAAABQlBMnTig4OLjQx2m6UQoOh0OHDx9WjRo1ZLPZivWczMxMRURE6NChQzTqKATvUdF4f4rG+1M03p8L4z0qGu9P0Xh/imbF+2MYhk6cOKHw8HCnjsXnY2a4FPz8/FSvXr1SPbdmzZr8kFwA71HReH+KxvtTNN6fC+M9KhrvT9F4f4pW3u9PUTPCZ3EBHQAAAHwWYRgAAAA+izBcTgIDAzVx4kQFBgZaXYrH4j0qGu9P0Xh/isb7c2G8R0Xj/Ska70/RPPn94QI6AAAA+CxmhgEAAOCzCMMAAADwWYRhAAAA+CzCMAAAAHwWYdiNZs+erQYNGigoKEjR0dHasGFDked/+OGHatq0qYKCgtSiRQutWLGinCotf1OnTlW7du1Uo0YNXXrpperZs6f27NlT5HMWLVokm83mdAsKCiqnisvXM888k++1Nm3atMjn+NLnp0GDBvneH5vNpuHDhxd4vi98dtauXavbbrtN4eHhstlsWr58udPjhmFowoQJqlOnjqpUqaKYmBglJydfcNyS/h7zVEW9P2fOnNGYMWPUokULVatWTeHh4RowYIAOHz5c5Jil+Tn1VBf6/AwaNCjfa+3WrdsFx/WFz4+kAn8f2Ww2vfjii4WO6U2fn+L8nX769GkNHz5cF198sapXr64777xTqampRY5b2t9briIMu8nSpUsVFxeniRMnatOmTWrVqpViY2OVlpZW4Pnff/+9+vXrpyFDhmjz5s3q2bOnevbsqR07dpRz5eXjm2++0fDhw/XDDz9o1apVOnPmjLp27aqsrKwin1ezZk0dOXIk73bgwIFyqrj8XXXVVU6v9dtvvy30XF/7/Pz4449O782qVaskSb179y70Od7+2cnKylKrVq00e/bsAh+fNm2aZs6cqblz52r9+vWqVq2aYmNjdfr06ULHLOnvMU9W1Ptz6tQpbdq0SePHj9emTZv08ccfa8+ePbr99tsvOG5Jfk492YU+P5LUrVs3p9e6ZMmSIsf0lc+PJKf35ciRI1q4cKFsNpvuvPPOIsf1ls9Pcf5Of+yxx/TZZ5/pww8/1DfffKPDhw+rV69eRY5bmt9bbmHALdq3b28MHz48735ubq4RHh5uTJ06tcDz7777buOWW25xOhYdHW088MADZVqnp0hLSzMkGd98802h57z11ltGcHBw+RVloYkTJxqtWrUq9vm+/vkZOXKk0bhxY8PhcBT4uC99dgzDMCQZy5Yty7vvcDiMsLAw48UXX8w7lp6ebgQGBhpLliwpdJyS/h6rKM5/fwqyYcMGQ5Jx4MCBQs8p6c9pRVHQ+zNw4ECjR48eJRrHlz8/PXr0MG688cYiz/HWz49h5P87PT093ahcubLx4Ycf5p3z888/G5KMpKSkAsco7e8td2Bm2A1ycnK0ceNGxcTE5B3z8/NTTEyMkpKSCnxOUlKS0/mSFBsbW+j53iYjI0OSVLt27SLPO3nypOrXr6+IiAj16NFDO3fuLI/yLJGcnKzw8HA1atRI9957rw4ePFjoub78+cnJydF//vMf/fOf/5TNZiv0PF/67Jxv3759SklJcfqMBAcHKzo6utDPSGl+j3mTjIwM2Ww2XXTRRUWeV5Kf04ouMTFRl156qa644go99NBDOn78eKHn+vLnJzU1VV988YWGDBlywXO99fNz/t/pGzdu1JkzZ5w+D02bNtVll11W6OehNL+33IUw7AbHjh1Tbm6uQkNDnY6HhoYqJSWlwOekpKSU6Hxv4nA4NGrUKF133XVq3rx5oeddccUVWrhwoT755BP95z//kcPh0LXXXiu73V6O1ZaP6OhoLVq0SCtXrtScOXO0b98+dezYUSdOnCjwfF/+/Cxfvlzp6ekaNGhQoef40menIGc/ByX5jJTm95i3OH36tMaMGaN+/fqpZs2ahZ5X0p/Tiqxbt2565513FB8frxdeeEHffPONunfvrtzc3ALP9+XPz9tvv60aNWpccAmAt35+Cvo7PSUlRQEBAfn+5/JCuejsOcV9jrtUKtPRgQIMHz5cO3bsuOBaqQ4dOqhDhw5596+99lpdeeWVmjdvnqZMmVLWZZar7t275/25ZcuWio6OVv369fXBBx8Ua7bBlyxYsEDdu3dXeHh4oef40mcHrjlz5ozuvvtuGYahOXPmFHmuL/2c9u3bN+/PLVq0UMuWLdW4cWMlJiaqS5cuFlbmeRYuXKh77733ghfpeuvnp7h/p3syZobdICQkRP7+/vmukkxNTVVYWFiBzwkLCyvR+d7ikUce0eeff66EhATVq1evRM+tXLmyWrdurb1795ZRdZ7joosu0uWXX17oa/XVz8+BAwe0evVq3X///SV6ni99diTlfQ5K8hkpze+xiu5sED5w4IBWrVpV5KxwQS70c+pNGjVqpJCQkEJfqy9+fiRp3bp12rNnT4l/J0ne8fkp7O/0sLAw5eTkKD093en8C+Wis+cU9znuQhh2g4CAALVp00bx8fF5xxwOh+Lj451mp/6uQ4cOTudL0qpVqwo9v6IzDEOPPPKIli1bpjVr1qhhw4YlHiM3N1fbt29XnTp1yqBCz3Ly5En9+uuvhb5WX/v8nPXWW2/p0ksv1S233FKi5/nSZ0eSGjZsqLCwMKfPSGZmptavX1/oZ6Q0v8cqsrNBODk5WatXr9bFF19c4jEu9HPqTex2u44fP17oa/W1z89ZCxYsUJs2bdSqVasSP7cif34u9Hd6mzZtVLlyZafPw549e3Tw4MFCPw+l+b3lNmV6eZ4Pef/9943AwEBj0aJFxq5du4xhw4YZF110kZGSkmIYhmH079/fGDt2bN753333nVGpUiVj+vTpxs8//2xMnDjRqFy5srF9+3arXkKZeuihh4zg4GAjMTHROHLkSN7t1KlTeeec/x5NmjTJ+Oqrr4xff/3V2Lhxo9G3b18jKCjI2LlzpxUvoUw9/vjjRmJiorFv3z7ju+++M2JiYoyQkBAjLS3NMAw+P4ZhXpl+2WWXGWPGjMn3mC9+dk6cOGFs3rzZ2Lx5syHJePnll43Nmzfn7Ybw/PPPGxdddJHxySefGNu2bTN69OhhNGzY0Pjzzz/zxrjxxhuN1157Le/+hX6PVSRFvT85OTnG7bffbtSrV8/YsmWL0++k7OzsvDHOf38u9HNakRT1/pw4ccIYPXq0kZSUZOzbt89YvXq1cfXVVxtNmjQxTp8+nTeGr35+zsrIyDCqVq1qzJkzp8AxvPnzU5y/0x988EHjsssuM9asWWP89NNPRocOHYwOHTo4jXPFFVcYH3/8cd794vzeKguEYTd67bXXjMsuu8wICAgw2rdvb/zwww95j91www3GwIEDnc7/4IMPjMsvv9wICAgwrrrqKuOLL74o54rLj6QCb2+99VbeOee/R6NGjcp7P0NDQ42bb77Z2LRpU/kXXw769Olj1KlTxwgICDDq1q1r9OnTx9i7d2/e477++TEMw/jqq68MScaePXvyPeaLn52EhIQCf6bOvg8Oh8MYP368ERoaagQGBhpdunTJ997Vr1/fmDhxotOxon6PVSRFvT/79u0r9HdSQkJC3hjnvz8X+jmtSIp6f06dOmV07drVuOSSS4zKlSsb9evXN4YOHZov1Prq5+esefPmGVWqVDHS09MLHMObPz/F+Tv9zz//NB5++GGjVq1aRtWqVY077rjDOHLkSL5x/v6c4vzeKgu2/y8GAAAA8DmsGQYAAIDPIgwDAADAZxGGAQAA4LMIwwAAAPBZhGEAAAD4LMIwAAAAfBZhGAAAAD6LMAwAAACfRRgGAACAzyIMAwDc5tChQ+rcubOaNWumli1b6sMPP7S6JAAoEu2YAQBuc+TIEaWmpioqKkopKSlq06aNfvnlF1WrVs3q0gCgQMwMA4CX69y5s2w2m2w2m7Zs2VKm36tOnTqKioqSJIWFhSkkJES///573uODBg3Kq2X58uVlWgsAFAdhGAB8wNChQ3XkyBE1b9683L7nxo0blZubq4iIiLxjr776qo4cOVJuNQDAhVSyugAAQNmrWrWqwsLC3DJWVFSU/vrrr3zHv/76a4WHh0uSfv/9dw0YMEBvvPGG0znBwcEKDg52Sx0A4A7MDAOAB+rcubMeffRRPfnkk6pdu7bCwsL0zDPPuPV77N+/XzabTf/973/VqVMnValSRe3atdPBgwe1bt06XXPNNapataq6dOmi9PT0vOdt2bJFO3bsyHc7G4Szs7PVs2dPjR07Vtdee61bawYAdyMMA4CHevvtt1WtWjWtX79e06ZN0+TJk7Vq1Sq3jb9161ZJ0pw5c/Tcc8/p+++/V2pqqu677z49//zzmjVrlhISErR161a99dZbxRrTMAwNGjRIN954o/r37++2WgGgrLBMAgA8VMuWLTVx4kRJUpMmTTRr1izFx8frpptucsv4W7ZsUe3atbV06VJdfPHFkqQbbrhB3377rXbu3KmqVatKktq1a6eUlJRijfndd99p6dKlatmyZd4FcosXL1aLFi3cUjMAuBthGAA8VMuWLZ3u16lTR2lpaTp06JD69++vtLQ0VapUSePHj1fv3r1LPP7WrVt1xx135AVhSTp48KD69OmTF4TPHuvRo0exxrz++uvlcDhKXAsAWIVlEgDgoSpXrux032azyeFwqFKlSpoxY4Z27dqlr7/+WqNGjVJWVlaJx9+yZYuio6Odjm3dulXXXHNN3v3Tp09rz549atWqVeleBAB4OGaGAaCCqVOnjurUqSPJeS/fkjS2yMzM1P79+9W6deu8Y/v27VNGRobTse3bt8swDJY5APBazAwDQAVW0F6+xbF161b5+/s77Tt8dg1x/fr1nY41btxY1atXd1vNAOBJmBkGgAqqsL18i2Pr1q264oorFBQU5HTs77PCZ4+xRAKAN7MZhmFYXQQAoGSys7N10003aejQoRfcwqxz586KiorSjBkzyqe4YrDZbFq2bJl69uxpdSkAfBzLJACgginNXr6vv/66qlevru3bt5dxdUV78MEHWXIBwKMwMwwAFcy3336rTp06OW29VtRevr/99pv+/PNPSdJll12mgICAcqmzIGlpacrMzJRkXghYkov+AKAsEIYBAADgs1gmAQAAAJ9FGAYAAIDPIgwDAADAZxGGAQAA4LMIwwAAAPBZhGEAAAD4LMIwAAAAfBZhGAAAAD6LMAwAAACfRRgGAACAzyIMAwAAwGcRhgEAAOCz/g/P5iiO3JwJygAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 800x650 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot alpha vs n2\n",
+    "fig = plt.figure(figsize=(8,6.5))\n",
+    "ax = fig.gca()\n",
+    "ax.plot(n2_vals, alpha_vals,'r.-', lw = 1)\n",
+    "ax.set_xlabel(r'n$_2$ [$m^{-2}$]')\n",
+    "ax.set_ylabel(r'phase curvature, $\\alpha$ [$\\mu m^{-1}$]')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_pi_jvt: 0.170068 [1/m], alpha_sigma_jvt: 0.105042 [1/m]\n",
+      "alpha_pi_abcd: 0.176284 [1/m]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# measured focal lengths (as of 02012023) - convert to alpha values\n",
+    "f_pi_jvt = 2.94       # focal length [m]\n",
+    "f_sigma_jvt = 4.76    # focal length [m]\n",
+    "\n",
+    "alpha_pi_jvt = 1 / (2 * f_pi_jvt)\n",
+    "alpha_sigma_jvt = 1 / (2 * f_sigma_jvt)\n",
+    "\n",
+    "print('alpha_pi_jvt: %g [1/m], alpha_sigma_jvt: %g [1/m]' %(alpha_pi_jvt, alpha_sigma_jvt))\n",
+    "print('alpha_pi_abcd: %g [1/m]' %(alpha_abcd))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "f_pi_jvt: 2.94 [m], f_pi_abcd: 2.83633 [m]\n"
+     ]
+    }
+   ],
+   "source": [
+    "f_pi_abcd = 1 / 2 / alpha_abcd\n",
+    "\n",
+    "print('f_pi_jvt: %g [m], f_pi_abcd: %g [m]' %(f_pi_jvt, f_pi_abcd))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Calculate radius of curvature and displacement required for thin lens via lens maker's equation - focal length agreement"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\begin{equation}\n",
+    "\\frac{1}{f} = \\frac{n_l - n_{air}}{n_{air}} \\left(\\frac{1}{R_1} - \\frac{1}{R_2} \\right)\n",
+    "\\end{equation}\n",
+    "where $R_1$ and $R_2$ are the front back radii of curvature respectively.\n",
+    "\n",
+    "Now let $R_2 \\rightarrow \\infty$, then\n",
+    "\\begin{equation}\n",
+    "\\frac{1}{f} = \\frac{n_l - n_{air}}{R_1 n_{air}}\n",
+    "\\end{equation}\n",
+    "\n",
+    "\n",
+    "For a more precise calculation, we may consider the more general formula,\n",
+    "\\begin{equation}\n",
+    "\\frac{1}{f} = (n_l - 1) \\left[\\frac{1}{R_1} - \\frac{1}{R_2} + \\frac{(n_l-1)d}{n_l R_1 R_2} \\right]\n",
+    "\\end{equation}\n",
+    "where d is the crystal length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "$R_1$ = 3.797 [m]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# define inputs for len's makers formula\n",
+    "n_l = 1.75991         # index of refraction (n_0) for Ti-Sapphire\n",
+    "n_air = 1.00029       # index of refraction for air\n",
+    "\n",
+    "# calculate radius of curvature for displacement at crystal entrance\n",
+    "R_1 = flen_front * (n_l - n_air) / n_air\n",
+    "\n",
+    "printmd(r'$R_1$ = %g [m]' %(R_1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\begin{equation}\n",
+    "x = R - \\sqrt{R^2 - r^2} \n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "diseplacement at crystal entrance: 3.29208 [$\\mu m$]"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# calculate displacement at crystal entrance\n",
+    "r_crystal = 0.005     # crystal radius [m]\n",
+    "disp_ent = R_1 - np.sqrt(R_1**2 - r_crystal**2)\n",
+    "printmd(r'diseplacement at crystal entrance: %g [$\\mu m$]' %(disp_ent*1e6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "py3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  },
+  "toc-autonumbering": false,
+  "toc-showmarkdowntxt": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
@bnash and I added a thermomechanical displacement calculation to the linear optics notebook which lets us determine the displacement required to get focusing agreement between simulation and experiment with the common K_c = 0.33 W/cm/K.  We include ABCD matrices , calculated via FEniCS thermal simulation, for varying K_c and calculate resultant wavefront focal lengths.