### PR TITLE
Fix #41: pop inversion crystal params

### DIFF
--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -372,19 +372,10 @@ class CrystalSlice(Element):
         return left_pump_mesh + right_pump_mesh
 
     def _initialize_excited_states_mesh(self, params, nslice):
-        # TODO (gurhar1133): loop over params and use names to build
-        self.population_inversion = PKDict(
-            n_cells=params.pop_inversion_n_cells,
-            mesh_extent=params.pop_inversion_mesh_extent,
-            crystal_alpha=params.pop_inversion_crystal_alpha,
-            pump_waist=params.pop_inversion_pump_waist,
-            pump_wavelength=params.pop_inversion_pump_wavelength,
-            pump_energy=params.pop_inversion_pump_energy,
-            pump_type=params.pop_inversion_pump_type,
-            pump_gaussian_order=params.pop_inversion_pump_gaussian_order,
-            pump_offset_x=params.pop_inversion_pump_offset_x,
-            pump_offset_y=params.pop_inversion_pump_offset_y,
-        )
+        self.population_inversion = PKDict()
+        for k in params:
+            if "pop_inversion" in k:
+                self.population_inversion[k.replace("pop_inversion_", "")] = params[k]
         x = np.linspace(
             -self.population_inversion.mesh_extent,
             self.population_inversion.mesh_extent,

--- a/rslaser/optics/crystal.py
+++ b/rslaser/optics/crystal.py
@@ -161,7 +161,7 @@ class Crystal(Element):
                 laser_pulse = laser_pulse.combine_n2_variation(
                     laser_pulse_copies,
                     s.radial_n2_factor,
-                    s.pop_inversion_pump_waist,
+                    s.population_inversion.pump_waist,
                     s.n2,
                 )
             else:

--- a/tests/element_test.py
+++ b/tests/element_test.py
@@ -21,6 +21,14 @@ def test_instantiation01():
             pykern.pkunit.pkfail(
                 "CrystalSlice had length not equal to Crystal wrapper length/nslice"
             )
+    crystal.Crystal(
+            PKDict(
+            nslice=10,
+            population_inversion=PKDict(
+                n_cell=32,
+            ),
+        )
+    )
 
 
 def test_crystal_nslice():

--- a/tests/element_test.py
+++ b/tests/element_test.py
@@ -24,9 +24,7 @@ def test_instantiation01():
     crystal.Crystal(
             PKDict(
             nslice=10,
-            population_inversion=PKDict(
-                n_cell=32,
-            ),
+            pop_inversion_n_cells=32,
         )
     )
 

--- a/tests/element_test.py
+++ b/tests/element_test.py
@@ -22,7 +22,7 @@ def test_instantiation01():
                 "CrystalSlice had length not equal to Crystal wrapper length/nslice"
             )
     crystal.Crystal(
-            PKDict(
+        PKDict(
             nslice=10,
             pop_inversion_n_cells=32,
         )


### PR DESCRIPTION
flattened the crystal params. Adjusted calls/references to population_inversion sub dict